### PR TITLE
Fix typo in macro docs

### DIFF
--- a/src/ketos/value.rs
+++ b/src/ketos/value.rs
@@ -782,7 +782,7 @@ macro_rules! integer_from_ref {
 /// Generates conversion trait implementations for the given type.
 ///
 /// ```ignore
-/// foreign_type_conversions!{ MyType = "my-type" }
+/// foreign_type_conversions!{ MyType => "my-type" }
 /// ```
 #[macro_export]
 macro_rules! foreign_type_conversions {


### PR DESCRIPTION
Changes `=` to `=>` in the docs of `foreign_type_conversions!`