### PR TITLE
Ran 'cargo fmt'

### DIFF
--- a/benches/core.rs
+++ b/benches/core.rs
@@ -25,7 +25,9 @@ fn run_bench(b: &mut Bencher, setup: &str, input: &str) {
 }
 
 fn factorial(b: &mut Bencher, n: u32) {
-    run_bench(b, r#"
+    run_bench(
+        b,
+        r#"
         (define (factorial n) (fac-recursive n 1))
 
         (define (fac-recursive n acc)
@@ -33,11 +35,14 @@ fn factorial(b: &mut Bencher, n: u32) {
             acc
             (fac-recursive (- n 1) (* n acc))))
         "#,
-        &format!("(factorial {})", n));
+        &format!("(factorial {})", n),
+    );
 }
 
 fn fib(b: &mut Bencher, n: u32) {
-    run_bench(b, r#"
+    run_bench(
+        b,
+        r#"
         (define (fib n) (fib-recursive n 0 1))
 
         (define (fib-recursive n a b)
@@ -45,7 +50,8 @@ fn fib(b: &mut Bencher, n: u32) {
             a
             (fib-recursive (- n 1) b (+ a b))))
         "#,
-        &format!("(fib {})", n));
+        &format!("(fib {})", n),
+    );
 }
 
 #[bench]
@@ -53,9 +59,13 @@ fn bench_compile_0(b: &mut Bencher) {
     b.iter(|| {
         let interp = Interpreter::new();
 
-        interp.compile_single_expr(r#"
+        interp
+            .compile_single_expr(
+                r#"
             (define (foo) ())
-            "#, None).unwrap();
+            "#,
+                None,
+            ).unwrap();
     });
 }
 
@@ -64,10 +74,14 @@ fn bench_compile_1(b: &mut Bencher) {
     b.iter(|| {
         let interp = Interpreter::new();
 
-        interp.compile_single_expr(r#"
+        interp
+            .compile_single_expr(
+                r#"
             (define (foo a b)
               (if (< a b) a b))
-            "#, None).unwrap();
+            "#,
+                None,
+            ).unwrap();
     });
 }
 
@@ -76,7 +90,9 @@ fn bench_compile_2(b: &mut Bencher) {
     b.iter(|| {
         let interp = Interpreter::new();
 
-        interp.compile_single_expr(r#"
+        interp
+            .compile_single_expr(
+                r#"
             (define (foo a b :optional (c 0) (d c))
               (if a
                 b
@@ -87,7 +103,9 @@ fn bench_compile_2(b: &mut Bencher) {
                                 ((= a 'a) 'alpha)
                                 ((<= b 9) 'beta)
                                 (else     'gamma))))))
-            "#, None).unwrap();
+            "#,
+                None,
+            ).unwrap();
     });
 }
 

--- a/examples/calling.rs
+++ b/examples/calling.rs
@@ -2,7 +2,7 @@
 
 extern crate ketos;
 
-use ketos::{Interpreter, FromValueRef};
+use ketos::{FromValueRef, Interpreter};
 
 fn main() {
     // First, create an interpreter.
@@ -10,13 +10,17 @@ fn main() {
 
     // Run some code that defines a function.
     // This will insert the newly defined function into the interpreter scope.
-    interp.run_code(r#"
+    interp
+        .run_code(
+            r#"
         (define (factorial n)
           (cond
             ((< n 0) (panic "factorial got negative integer"))
             ((<= n 1) 1)
             (else (* n (factorial (- n 1))))))
-        "#, None).unwrap();
+        "#,
+            None,
+        ).unwrap();
 
     // Call the function by name, converting Rust values using the Into trait.
     let v = interp.call("factorial", vec![5.into()]).unwrap();

--- a/examples/interop.rs
+++ b/examples/interop.rs
@@ -1,7 +1,9 @@
 //! Demonstrates interoperation -- calling methods on Rust values from Ketos
 
-#[macro_use] extern crate ketos;
-#[macro_use] extern crate ketos_derive;
+#[macro_use]
+extern crate ketos;
+#[macro_use]
+extern crate ketos_derive;
 
 use std::cell::Cell;
 use std::rc::Rc;
@@ -17,7 +19,7 @@ pub struct Hello {
 impl Hello {
     /// Creates a new `Hello` to say "Hello" to `who`.
     pub fn new(who: String) -> Hello {
-        Hello{who: who}
+        Hello { who: who }
     }
 
     /// Returns a string saying "Hello" to someone.
@@ -38,7 +40,9 @@ pub struct Counter {
 impl Counter {
     /// Creates a new `Counter` with counter value `0`.
     pub fn new() -> Counter {
-        Counter{count: Cell::new(0)}
+        Counter {
+            count: Cell::new(0),
+        }
     }
 
     /// Increments the internal counter and returns the previous value.
@@ -71,22 +75,30 @@ fn main() {
 
     // Inserts wrapper functions into the global scope.
     ketos_fn!{ interp.scope() => "count" =>
-        fn count(counter: &Counter) -> u32 }
+    fn count(counter: &Counter) -> u32 }
     ketos_fn!{ interp.scope() => "say-hello" =>
-        fn say_hello(hello: &Hello) -> String }
+    fn say_hello(hello: &Hello) -> String }
 
     // Defines a `main` function within the global scope to accept our values.
-    interp.run_code(r#"
+    interp
+        .run_code(
+            r#"
         (define (main hello counter)
           (do
             (println "Hello from Ketos: ~a" (say-hello hello))
             (println "Count from Ketos: ~a" (count counter))))
-        "#, None).unwrap();
+        "#,
+            None,
+        ).unwrap();
 
-    interp.call("main", vec![
-        Value::Foreign(hello.clone()),
-        Value::Foreign(counter.clone()),
-    ]).unwrap();
+    interp
+        .call(
+            "main",
+            vec![
+                Value::Foreign(hello.clone()),
+                Value::Foreign(counter.clone()),
+            ],
+        ).unwrap();
 
     println!("Hello from Rust: {}", hello.say_hello());
     println!("Count from Rust: {}", counter.count());

--- a/examples/module.rs
+++ b/examples/module.rs
@@ -1,28 +1,26 @@
 //! Example module construction
 
-#[macro_use] extern crate ketos;
+#[macro_use]
+extern crate ketos;
 
 use ketos::{
-    CompileError,
-    Context,
-    Error,
-    Interpreter,
-    BuiltinModuleLoader, Module, ModuleBuilder, ModuleLoader,
-    Name,
-    Scope,
-    FromValue,
+    BuiltinModuleLoader, CompileError, Context, Error, FromValue, Interpreter, Module,
+    ModuleBuilder, ModuleLoader, Name, Scope,
 };
 
 fn main() {
     // Create an interpreter using our custom loader
-    let interp = Interpreter::with_loader(
-        Box::new(CustomModuleLoader.chain(BuiltinModuleLoader)));
+    let interp = Interpreter::with_loader(Box::new(CustomModuleLoader.chain(BuiltinModuleLoader)));
 
     // Import our custom module and run the imported function
-    let v = interp.run_code(r#"
+    let v = interp
+        .run_code(
+            r#"
         (use custom (hello))
         (hello "world")
-        "#, None).unwrap();
+        "#,
+            None,
+        ).unwrap();
 
     // Pull a String value out of the result
     let s = String::from_value(v).unwrap();

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,9 +1,10 @@
 //! Defining a struct that can be constructed in Ketos
 
 extern crate ketos;
-#[macro_use] extern crate ketos_derive;
+#[macro_use]
+extern crate ketos_derive;
 
-use ketos::{Interpreter, FromValue};
+use ketos::{FromValue, Interpreter};
 
 // Define a struct with necessary conversion traits
 #[derive(Clone, Debug, ForeignValue, FromValueClone, StructValue)]
@@ -27,12 +28,16 @@ fn main() {
 
     // These structs are created just like Ketos-defined struct types,
     // using the `new` function.
-    let value = interp.run_code(r#"
+    let value = interp
+        .run_code(
+            r#"
         (new Thing
             :name "thing-1"
             :thing-count 9000
             :type "thing")
-        "#, None).unwrap();
+        "#,
+            None,
+        ).unwrap();
 
     // Extract the `Thing` from the Ketos value.
     let thing = Thing::from_value(value).unwrap();

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -1,5 +1,6 @@
 extern crate dirs;
-#[macro_use] extern crate gumdrop;
+#[macro_use]
+extern crate gumdrop;
 extern crate ketos;
 extern crate linefeed;
 
@@ -14,12 +15,11 @@ use std::time::Duration;
 
 use gumdrop::{Options, ParsingStyle};
 use ketos::{
-    Builder, Interpreter, complete_name,
-    Context, Error, RestrictConfig, ParseError, ParseErrorKind,
+    complete_name, Builder, Context, Error, Interpreter, ParseError, ParseErrorKind, RestrictConfig,
 };
 use linefeed::{
-    Interface, Prompter, Command, Completer,
-    Completion, Function, ReadResult, Signal, Suffix, Terminal,
+    Command, Completer, Completion, Function, Interface, Prompter, ReadResult, Signal, Suffix,
+    Terminal,
 };
 
 fn main() {
@@ -37,15 +37,25 @@ struct KetosOpts {
     #[options(short = "V", help = "Print version and exit")]
     version: bool,
 
-    #[options(no_long, help = "Evaluate one expression and exit", meta = "EXPR")]
+    #[options(
+        no_long,
+        help = "Evaluate one expression and exit",
+        meta = "EXPR"
+    )]
     expr: Option<String>,
     #[options(help = "Run interactively even with a file")]
     interactive: bool,
-    #[options(no_long, help = "Add DIR to list of module search paths", meta = "DIR")]
+    #[options(
+        no_long,
+        help = "Add DIR to list of module search paths",
+        meta = "DIR"
+    )]
     include: Vec<String>,
-    #[options(short = "R",
+    #[options(
+        short = "R",
         help = "Configure execution restrictions; see `-R help` for more details",
-        meta = "SPEC")]
+        meta = "SPEC"
+    )]
     restrict: Option<String>,
     #[options(no_short, help = "Do not run ~/.ketosrc.ket on startup")]
     no_rc: bool,
@@ -81,8 +91,7 @@ fn run() -> i32 {
 
     paths.extend(opts.include.into_iter().map(PathBuf::from));
 
-    let mut builder = Builder::new()
-        .search_paths(paths);
+    let mut builder = Builder::new().search_paths(paths);
 
     if let Some(ref res) = opts.restrict {
         if res == "help" {
@@ -101,8 +110,7 @@ fn run() -> i32 {
 
     let interp = builder.finish();
 
-    let interactive = opts.interactive ||
-        (opts.free.is_empty() && opts.expr.is_none());
+    let interactive = opts.interactive || (opts.free.is_empty() && opts.expr.is_none());
 
     if let Some(ref expr) = opts.expr {
         if !run_expr(&interp, &expr) && !interactive {
@@ -145,26 +153,20 @@ fn parse_restrict(params: &str) -> Result<RestrictConfig, String> {
             _ => {
                 let (name, value) = match param.find('=') {
                     Some(pos) => (&param[..pos], &param[pos + 1..]),
-                    None => return Err(format!("unrecognized restrict option: {}", param))
+                    None => return Err(format!("unrecognized restrict option: {}", param)),
                 };
 
                 match name {
-                    "execution_time" =>
-                        res.execution_time = Some(Duration::from_millis(
-                            parse_param(name, value)?)),
-                    "call_stack_size" =>
-                        res.call_stack_size = parse_param(name, value)?,
-                    "value_stack_size" =>
-                        res.value_stack_size = parse_param(name, value)?,
-                    "namespace_size" =>
-                        res.namespace_size = parse_param(name, value)?,
-                    "memory_limit" =>
-                        res.memory_limit = parse_param(name, value)?,
-                    "max_integer_size" =>
-                        res.max_integer_size = parse_param(name, value)?,
-                    "max_syntax_nesting" =>
-                        res.max_syntax_nesting = parse_param(name, value)?,
-                    _ => return Err(format!("unrecognized parameter: {}", name))
+                    "execution_time" => {
+                        res.execution_time = Some(Duration::from_millis(parse_param(name, value)?))
+                    }
+                    "call_stack_size" => res.call_stack_size = parse_param(name, value)?,
+                    "value_stack_size" => res.value_stack_size = parse_param(name, value)?,
+                    "namespace_size" => res.namespace_size = parse_param(name, value)?,
+                    "memory_limit" => res.memory_limit = parse_param(name, value)?,
+                    "max_integer_size" => res.max_integer_size = parse_param(name, value)?,
+                    "max_syntax_nesting" => res.max_syntax_nesting = parse_param(name, value)?,
+                    _ => return Err(format!("unrecognized parameter: {}", name)),
                 }
             }
         }
@@ -174,7 +176,9 @@ fn parse_restrict(params: &str) -> Result<RestrictConfig, String> {
 }
 
 fn parse_param<T: FromStr>(name: &str, value: &str) -> Result<T, String> {
-    value.parse().map_err(|_| format!("invalid `{}` value: {}", name, value))
+    value
+        .parse()
+        .map_err(|_| format!("invalid `{}` value: {}", name, value))
 }
 
 fn display_error(interp: &Interpreter, e: &Error) {
@@ -246,7 +250,7 @@ fn run_repl(interp: &Interpreter) -> io::Result<()> {
                         if !code.is_empty() {
                             match interp.execute_program(code) {
                                 Ok(v) => interp.display_value(&v),
-                                Err(e) => display_error(&interp, &e)
+                                Err(e) => display_error(&interp, &e),
                             }
                         }
                     }
@@ -287,32 +291,41 @@ fn set_thread_context(ctx: Context) {
 
 fn thread_context() -> Context {
     CONTEXT.with(|key| {
-        key.borrow().clone().unwrap_or_else(
-            || panic!("no thread-local Context object set"))
+        key.borrow()
+            .clone()
+            .unwrap_or_else(|| panic!("no thread-local Context object set"))
     })
 }
 
 impl<Term: Terminal> Completer<Term> for KetosCompleter {
-    fn complete(&self, word: &str, prompter: &Prompter<Term>,
-            start: usize, end: usize) -> Option<Vec<Completion>> {
-        let line_start = prompter.buffer()[..start].rfind('\n')
-            .map(|pos| pos + 1).unwrap_or(0);
+    fn complete(
+        &self,
+        word: &str,
+        prompter: &Prompter<Term>,
+        start: usize,
+        end: usize,
+    ) -> Option<Vec<Completion>> {
+        let line_start = prompter.buffer()[..start]
+            .rfind('\n')
+            .map(|pos| pos + 1)
+            .unwrap_or(0);
         let is_whitespace = prompter.buffer()[line_start..start]
-            .chars().all(|ch| ch.is_whitespace());
+            .chars()
+            .all(|ch| ch.is_whitespace());
 
         if is_whitespace && start == end {
             // Indent when there's no word to complete
             let n = 2 - (start - line_start) % 2;
 
-            Some(vec![Completion{
+            Some(vec![Completion {
                 completion: repeat(' ').take(n).collect(),
                 display: None,
                 suffix: Suffix::None,
             }])
         } else {
             let ctx = thread_context();
-            complete_name(word, ctx.scope()).map(
-                |words| words.into_iter().map(Completion::simple).collect())
+            complete_name(word, ctx.scope())
+                .map(|words| words.into_iter().map(Completion::simple).collect())
         }
     }
 }
@@ -327,10 +340,22 @@ impl<Term: Terminal> Function<Term> for KetosAccept {
         interp.clear_codemap();
 
         match r {
-            Err(Error::ParseError(ParseError{kind: ParseErrorKind::MissingCloseParen, ..})) |
-            Err(Error::ParseError(ParseError{kind: ParseErrorKind::UnterminatedComment, ..})) |
-            Err(Error::ParseError(ParseError{kind: ParseErrorKind::UnterminatedString, ..})) |
-            Err(Error::ParseError(ParseError{kind: ParseErrorKind::DocCommentEof, ..})) => {
+            Err(Error::ParseError(ParseError {
+                kind: ParseErrorKind::MissingCloseParen,
+                ..
+            }))
+            | Err(Error::ParseError(ParseError {
+                kind: ParseErrorKind::UnterminatedComment,
+                ..
+            }))
+            | Err(Error::ParseError(ParseError {
+                kind: ParseErrorKind::UnterminatedString,
+                ..
+            }))
+            | Err(Error::ParseError(ParseError {
+                kind: ParseErrorKind::DocCommentEof,
+                ..
+            })) => {
                 if count > 0 {
                     prompter.insert(count as usize, '\n')
                 } else {
@@ -358,7 +383,7 @@ fn print_usage(arg0: &str) {
 
 fn print_restrict_usage() {
     print!(
-r#"The `-R` / `--restrict` option accepts a comma-separated list of parameters:
+        r#"The `-R` / `--restrict` option accepts a comma-separated list of parameters:
 
   permissive
     Applies "permissive" restrictions (default)
@@ -377,5 +402,6 @@ r#"The `-R` / `--restrict` option accepts a comma-separated list of parameters:
       memory_limit            Maximum total held memory, in abstract units
       max_integer_size        Maximum integer size, in bits
       max_syntax_nesting      Maximum nested syntax elements
-"#);
+"#
+    );
 }

--- a/src/ketos/any.rs
+++ b/src/ketos/any.rs
@@ -33,8 +33,9 @@ macro_rules! impl_any_cast {
             }
 
             /// Attempts to downcast a `Box<Trait>` to a concrete type.
-            pub fn downcast<T: $ty>(bx: ::std::boxed::Box<Self>)
-                    -> Result<::std::boxed::Box<T>, ::std::boxed::Box<Self>> {
+            pub fn downcast<T: $ty>(
+                bx: ::std::boxed::Box<Self>,
+            ) -> Result<::std::boxed::Box<T>, ::std::boxed::Box<Self>> {
                 if bx.is::<T>() {
                     unsafe {
                         let raw = ::std::boxed::Box::into_raw(bx);
@@ -47,8 +48,9 @@ macro_rules! impl_any_cast {
 
             /// Returns an owned `Rc` reference to the contained value,
             /// if it is of the given type.
-            pub fn downcast_rc<T: $ty>(rc: ::std::rc::Rc<Self>)
-                    -> Result<::std::rc::Rc<T>, ::std::rc::Rc<Self>> {
+            pub fn downcast_rc<T: $ty>(
+                rc: ::std::rc::Rc<Self>,
+            ) -> Result<::std::rc::Rc<T>, ::std::rc::Rc<Self>> {
                 if rc.is::<T>() {
                     unsafe {
                         let obj: $crate::any::TraitObject = ::std::mem::transmute(rc);
@@ -84,7 +86,7 @@ macro_rules! impl_any_cast {
                 }
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
@@ -106,13 +108,13 @@ mod test {
     #[derive(Debug)]
     struct Dumber;
 
-    impl SomeTrait for Dummy { }
+    impl SomeTrait for Dummy {}
 
-    impl SomeTrait for Dumber { }
+    impl SomeTrait for Dumber {}
 
     #[test]
     fn test_downcast() {
-        let a: Box<SomeTrait> = Box::new(Dummy{a: 0});
+        let a: Box<SomeTrait> = Box::new(Dummy { a: 0 });
 
         let b = SomeTrait::downcast::<Dumber>(a).unwrap_err();
         let c = SomeTrait::downcast::<Dummy>(b).unwrap();
@@ -122,7 +124,7 @@ mod test {
 
     #[test]
     fn test_downcast_rc() {
-        let a: Rc<SomeTrait> = Rc::new(Dummy{a: 0});
+        let a: Rc<SomeTrait> = Rc::new(Dummy { a: 0 });
 
         let b = SomeTrait::downcast_rc::<Dumber>(a).unwrap_err();
         let c = SomeTrait::downcast_rc::<Dummy>(b).unwrap();
@@ -132,7 +134,7 @@ mod test {
 
     #[test]
     fn test_downcast_ref() {
-        let mut a: Box<SomeTrait> = Box::new(Dummy{a: 0});
+        let mut a: Box<SomeTrait> = Box::new(Dummy { a: 0 });
 
         {
             let r = a.downcast_mut::<Dummy>().unwrap();

--- a/src/ketos/args.rs
+++ b/src/ketos/args.rs
@@ -136,7 +136,7 @@ mod test {
             let (a,) = ketos_args!(&args, (i32));
             assert_eq!(a, 1);
 
-            let (a,) = ketos_args!(&args, [ i32 ]);
+            let (a,) = ketos_args!(&args, [i32]);
             assert_eq!(a, Some(1));
 
             Ok(())
@@ -157,7 +157,7 @@ mod test {
             assert_eq!(c, Some(3));
             assert_eq!(d, None);
 
-            let (a, b, c, d) = ketos_args!(&args, [ i32, i32, i32, i32 ]);
+            let (a, b, c, d) = ketos_args!(&args, [i32, i32, i32, i32]);
 
             assert_eq!(a, Some(1));
             assert_eq!(b, Some(2));

--- a/src/ketos/bytes.rs
+++ b/src/ketos/bytes.rs
@@ -70,13 +70,19 @@ impl fmt::Debug for Bytes {
 }
 
 impl Extend<u8> for Bytes {
-    fn extend<I>(&mut self, iterable: I) where I: IntoIterator<Item=u8> {
+    fn extend<I>(&mut self, iterable: I)
+    where
+        I: IntoIterator<Item = u8>,
+    {
         self.0.extend(iterable);
     }
 }
 
 impl<'a> Extend<&'a u8> for Bytes {
-    fn extend<I>(&mut self, iterable: I) where I: IntoIterator<Item=&'a u8> {
+    fn extend<I>(&mut self, iterable: I)
+    where
+        I: IntoIterator<Item = &'a u8>,
+    {
         self.0.extend(iterable);
     }
 }
@@ -93,10 +99,14 @@ impl<'a> IntoIterator for &'a Bytes {
 macro_rules! impl_eq_vec {
     ( $lhs:ty, $rhs:ty ) => {
         impl<'a> PartialEq<$rhs> for $lhs {
-            fn eq(&self, rhs: &$rhs) -> bool { self[..] == rhs[..] }
-            fn ne(&self, rhs: &$rhs) -> bool { self[..] != rhs[..] }
+            fn eq(&self, rhs: &$rhs) -> bool {
+                self[..] == rhs[..]
+            }
+            fn ne(&self, rhs: &$rhs) -> bool {
+                self[..] != rhs[..]
+            }
         }
-    }
+    };
 }
 
 macro_rules! impl_eq_array {
@@ -128,16 +138,28 @@ impl_eq_array!{
 impl Eq for Bytes {}
 
 impl PartialOrd for Bytes {
-    fn partial_cmp(&self, rhs: &Bytes) -> Option<Ordering> { self.0.partial_cmp(&rhs.0) }
+    fn partial_cmp(&self, rhs: &Bytes) -> Option<Ordering> {
+        self.0.partial_cmp(&rhs.0)
+    }
 
-    fn lt(&self, rhs: &Bytes) -> bool { self.0 < rhs.0 }
-    fn le(&self, rhs: &Bytes) -> bool { self.0 <= rhs.0 }
-    fn gt(&self, rhs: &Bytes) -> bool { self.0 > rhs.0 }
-    fn ge(&self, rhs: &Bytes) -> bool { self.0 >= rhs.0 }
+    fn lt(&self, rhs: &Bytes) -> bool {
+        self.0 < rhs.0
+    }
+    fn le(&self, rhs: &Bytes) -> bool {
+        self.0 <= rhs.0
+    }
+    fn gt(&self, rhs: &Bytes) -> bool {
+        self.0 > rhs.0
+    }
+    fn ge(&self, rhs: &Bytes) -> bool {
+        self.0 >= rhs.0
+    }
 }
 
 impl Ord for Bytes {
-    fn cmp(&self, rhs: &Bytes) -> Ordering { self.0.cmp(&rhs.0) }
+    fn cmp(&self, rhs: &Bytes) -> Ordering {
+        self.0.cmp(&rhs.0)
+    }
 }
 
 impl From<String> for Bytes {

--- a/src/ketos/compile.rs
+++ b/src/ketos/compile.rs
@@ -5,21 +5,22 @@ use std::fmt;
 use std::mem::replace;
 use std::rc::Rc;
 
-use bytecode::{code_flags, Code, CodeBlock,
-    Instruction, JumpInstruction, MAX_SHORT_OPERAND};
-use const_fold::{is_one, is_negative_one,
-    FoldOp, FoldAdd, FoldSub, FoldDiv, FoldMul, FoldFloorDiv};
+use bytecode::{code_flags, Code, CodeBlock, Instruction, JumpInstruction, MAX_SHORT_OPERAND};
+use const_fold::{
+    is_negative_one, is_one, FoldAdd, FoldDiv, FoldFloorDiv, FoldMul, FoldOp, FoldSub,
+};
 use error::Error;
-use exec::{Context, ExecError, execute_lambda};
-use function::{Arity, Lambda};
+use exec::{execute_lambda, Context, ExecError};
 use function::Arity::*;
-use name::{get_system_fn, is_system_operator, standard_names,
-    Name, NameDisplay, NameMap, NameSet, NameStore,
-    NUM_SYSTEM_OPERATORS, SYSTEM_OPERATORS_BEGIN};
+use function::{Arity, Lambda};
+use name::{
+    get_system_fn, is_system_operator, standard_names, Name, NameDisplay, NameMap, NameSet,
+    NameStore, NUM_SYSTEM_OPERATORS, SYSTEM_OPERATORS_BEGIN,
+};
 use scope::{GlobalScope, ImportSet, MasterScope, Scope};
 use structs::{StructDef, StructValueDef};
-use trace::{Trace, TraceItem, set_traceback, take_traceback};
-use value::{Value, FromValueRef};
+use trace::{set_traceback, take_traceback, Trace, TraceItem};
+use value::{FromValueRef, Value};
 
 const MAX_MACRO_RECURSION: u32 = 100;
 
@@ -27,7 +28,7 @@ const MAX_MACRO_RECURSION: u32 = 100;
 #[derive(Debug)]
 pub enum CompileError {
     /// Error in arity for call to system function
-    ArityError{
+    ArityError {
         /// Name of function
         name: Name,
         /// Expected count or range of arguments
@@ -46,7 +47,7 @@ pub enum CompileError {
     /// Duplicate name in parameter list
     DuplicateParameter(Name),
     /// Attempt to export nonexistent name from module
-    ExportError{
+    ExportError {
         /// Module name
         module: Name,
         /// Imported name
@@ -55,7 +56,7 @@ pub enum CompileError {
     /// Recursion in module imports
     ImportCycle(Name),
     /// Attempt to import nonexistent name from module
-    ImportError{
+    ImportError {
         /// Module name
         module: Name,
         /// Imported name
@@ -80,7 +81,7 @@ pub enum CompileError {
     /// Operand value overflow
     OperandOverflow(u32),
     /// Attempt to import value that is not exported
-    PrivacyError{
+    PrivacyError {
         /// Module name
         module: Name,
         /// Imported name
@@ -97,31 +98,27 @@ impl fmt::Display for CompileError {
         use self::CompileError::*;
 
         match *self {
-            ArityError{expected, found, ..} =>
-                write!(f, "expected {}; found {}", expected, found),
-            CannotDefine(_) =>
-                f.write_str("cannot define name of standard value or operator"),
-            ConstantExists(_) =>
-                f.write_str("cannot define name occupied by a constant value"),
+            ArityError {
+                expected, found, ..
+            } => write!(f, "expected {}; found {}", expected, found),
+            CannotDefine(_) => f.write_str("cannot define name of standard value or operator"),
+            ConstantExists(_) => f.write_str("cannot define name occupied by a constant value"),
             DuplicateExports => f.write_str("duplicate `export` declaration"),
             DuplicateModuleDoc => f.write_str("duplicate module doc comment"),
             DuplicateParameter(_) => f.write_str("duplicate parameter"),
-            ExportError{..} => f.write_str("export name not found in module"),
+            ExportError { .. } => f.write_str("export name not found in module"),
             ImportCycle(_) => f.write_str("import cycle detected"),
-            ImportError{..} => f.write_str("import name not found in module"),
+            ImportError { .. } => f.write_str("import name not found in module"),
             ImportShadow(_) => f.write_str("shadowing an imported name"),
-            InvalidCallExpression(ty) =>
-                write!(f, "invalid call expression of type `{}`", ty),
-            InvalidCommaAt =>
-                f.write_str("`,@expr` form is invalid outside of a list"),
+            InvalidCallExpression(ty) => write!(f, "invalid call expression of type `{}`", ty),
+            InvalidCommaAt => f.write_str("`,@expr` form is invalid outside of a list"),
             InvalidModuleName(_) => f.write_str("invalid module name"),
             MacroRecursionExceeded => f.write_str("macro recursion exceeded"),
             MissingExport => f.write_str("missing `export` declaration"),
             ModuleError(_) => f.write_str("module not found"),
             NotConstant(_) => f.write_str("value is not constant"),
-            OperandOverflow(n) =>
-                write!(f, "operand overflow: {}", n),
-            PrivacyError{..} => f.write_str("name is private"),
+            OperandOverflow(n) => write!(f, "operand overflow: {}", n),
+            PrivacyError { .. } => f.write_str("name is private"),
             SyntaxError(e) => f.write_str(e),
             UnbalancedComma => f.write_str("unbalanced ` and ,"),
         }
@@ -133,28 +130,34 @@ impl NameDisplay for CompileError {
         use self::CompileError::*;
 
         match *self {
-            ArityError{name, ..} => write!(f, "`{}` {}", names.get(name), self),
-            CannotDefine(name) |
-            ConstantExists(name) |
-            DuplicateParameter(name) |
-            InvalidModuleName(name) |
-            ModuleError(name) |
-            NotConstant(name) => write!(f, "{}: {}", self, names.get(name)),
-            ExportError{module, name} =>
-                write!(f, "cannot export name `{}`; not found in module `{}`",
-                    names.get(name), names.get(module)),
-            ImportCycle(name) =>
-                write!(f, "import cycle in loading module `{}`", names.get(name)),
-            ImportError{module, name} =>
-                write!(f, "cannot import name `{}`; not found in module `{}`",
-                    names.get(name), names.get(module)),
-            ImportShadow(name) =>
-                write!(f, "shadowing imported name: {}",
-                    names.get(name)),
-            PrivacyError{module, name} =>
-                write!(f, "name `{}` in module `{}` is private",
-                    names.get(name), names.get(module)),
-            _ => fmt::Display::fmt(self, f)
+            ArityError { name, .. } => write!(f, "`{}` {}", names.get(name), self),
+            CannotDefine(name)
+            | ConstantExists(name)
+            | DuplicateParameter(name)
+            | InvalidModuleName(name)
+            | ModuleError(name)
+            | NotConstant(name) => write!(f, "{}: {}", self, names.get(name)),
+            ExportError { module, name } => write!(
+                f,
+                "cannot export name `{}`; not found in module `{}`",
+                names.get(name),
+                names.get(module)
+            ),
+            ImportCycle(name) => write!(f, "import cycle in loading module `{}`", names.get(name)),
+            ImportError { module, name } => write!(
+                f,
+                "cannot import name `{}`; not found in module `{}`",
+                names.get(name),
+                names.get(module)
+            ),
+            ImportShadow(name) => write!(f, "shadowing imported name: {}", names.get(name)),
+            PrivacyError { module, name } => write!(
+                f,
+                "name `{}` in module `{}` is private",
+                names.get(name),
+                names.get(module)
+            ),
+            _ => fmt::Display::fmt(self, f),
         }
     }
 }
@@ -163,20 +166,28 @@ impl NameDisplay for CompileError {
 pub fn compile(ctx: &Context, value: &Value) -> Result<Code, Error> {
     let mut compiler = Compiler::new(ctx);
 
-    compiler.compile(value)
-        .map_err(|e| { set_traceback(compiler.take_trace()); e })
+    compiler.compile(value).map_err(|e| {
+        set_traceback(compiler.take_trace());
+        e
+    })
 }
 
-fn compile_lambda(compiler: &mut Compiler,
-        name: Option<Name>,
-        params: Vec<(Name, Option<Value>)>,
-        req_params: u32,
-        kw_params: Vec<(Name, Option<Value>)>,
-        rest: Option<Name>, value: &Value)
-        -> Result<(Code, Vec<Name>), Error> {
+fn compile_lambda(
+    compiler: &mut Compiler,
+    name: Option<Name>,
+    params: Vec<(Name, Option<Value>)>,
+    req_params: u32,
+    kw_params: Vec<(Name, Option<Value>)>,
+    rest: Option<Name>,
+    value: &Value,
+) -> Result<(Code, Vec<Name>), Error> {
     let r = {
-        let outer = compiler.outer.iter().cloned()
-            .chain(Some(&*compiler)).collect::<Vec<_>>();
+        let outer = compiler
+            .outer
+            .iter()
+            .cloned()
+            .chain(Some(&*compiler))
+            .collect::<Vec<_>>();
 
         let mut sub = Compiler::with_outer(&compiler.ctx, name, &outer);
 
@@ -224,9 +235,12 @@ impl<'a> Compiler<'a> {
         Compiler::with_outer(ctx, None, &[])
     }
 
-    fn with_outer(ctx: &Context, name: Option<Name>,
-            outer: &'a [&'a Compiler<'a>]) -> Compiler<'a> {
-        Compiler{
+    fn with_outer(
+        ctx: &Context,
+        name: Option<Name>,
+        outer: &'a [&'a Compiler<'a>],
+    ) -> Compiler<'a> {
+        Compiler {
             ctx: ctx.clone(),
             consts: Vec::new(),
             blocks: vec![CodeBlock::new()],
@@ -286,7 +300,7 @@ impl<'a> Compiler<'a> {
             match b.jump {
                 Some((JumpInstruction::Jump, _)) => (),
                 Some((_, n)) => must_live[n as usize] = true,
-                _ => ()
+                _ => (),
             }
 
             if block_returns(&b, &self.blocks) {
@@ -315,7 +329,7 @@ impl<'a> Compiler<'a> {
 
             match next {
                 Some(n) => i = n as usize,
-                None => break
+                None => break,
             }
         }
 
@@ -338,7 +352,7 @@ impl<'a> Compiler<'a> {
         let code = self.assemble_code()?;
         let consts = replace(&mut self.consts, Vec::new());
 
-        Ok(Code{
+        Ok(Code {
             name: None,
             code: code,
             consts: consts.into_boxed_slice(),
@@ -350,14 +364,16 @@ impl<'a> Compiler<'a> {
         })
     }
 
-    fn compile_lambda(&mut self, name: Option<Name>,
-            params: Vec<(Name, Option<Value>)>,
-            req_params: u32,
-            kw_params: Vec<(Name, Option<Value>)>,
-            rest: Option<Name>, value: &Value)
-            -> Result<(Code, Vec<Name>), Error> {
-        let total_params = params.len() + kw_params.len() +
-            if rest.is_some() { 1 } else { 0 };
+    fn compile_lambda(
+        &mut self,
+        name: Option<Name>,
+        params: Vec<(Name, Option<Value>)>,
+        req_params: u32,
+        kw_params: Vec<(Name, Option<Value>)>,
+        rest: Option<Name>,
+        value: &Value,
+    ) -> Result<(Code, Vec<Name>), Error> {
+        let total_params = params.len() + kw_params.len() + if rest.is_some() { 1 } else { 0 };
 
         let n_params = params.len();
 
@@ -379,7 +395,8 @@ impl<'a> Compiler<'a> {
         // `param-` values are input parameters; `push-a` is the value of `a`
         // pushed onto the stack to be accepted by the call to `bar`.
         assert!(self.stack.is_empty());
-        self.stack.extend((0..total_params as u32).map(|n| (Name::dummy(), n)));
+        self.stack
+            .extend((0..total_params as u32).map(|n| (Name::dummy(), n)));
         self.stack_offset = total_params as u32;
 
         let mut flags = 0;
@@ -388,8 +405,10 @@ impl<'a> Compiler<'a> {
             flags |= code_flags::HAS_NAME;
         }
 
-        assert!(kw_params.is_empty() || rest.is_none(),
-            "keyword parameters and rest parameters are mutually exclusive");
+        assert!(
+            kw_params.is_empty() || rest.is_none(),
+            "keyword parameters and rest parameters are mutually exclusive"
+        );
 
         if !kw_params.is_empty() {
             flags |= code_flags::HAS_KW_PARAMS;
@@ -404,8 +423,7 @@ impl<'a> Compiler<'a> {
                 if let Some(default) = default {
                     self.branch_if_unbound(i as u32, &default)?;
                 } else {
-                    self.push_instruction(
-                        Instruction::UnboundToUnit(i as u32))?;
+                    self.push_instruction(Instruction::UnboundToUnit(i as u32))?;
                 }
             }
 
@@ -416,8 +434,7 @@ impl<'a> Compiler<'a> {
             if let Some(default) = default {
                 self.branch_if_unbound((n_params + i) as u32, &default)?;
             } else {
-                self.push_instruction(
-                    Instruction::UnboundToUnit((n_params + i) as u32))?;
+                self.push_instruction(Instruction::UnboundToUnit((n_params + i) as u32))?;
             }
 
             self.stack[n_params + i].0 = name;
@@ -435,7 +452,7 @@ impl<'a> Compiler<'a> {
         let consts = replace(&mut self.consts, Vec::new());
         let captures = replace(&mut self.captures, Vec::new());
 
-        let code = Code{
+        let code = Code {
             name: name,
             code: code,
             consts: consts.into_boxed_slice(),
@@ -453,8 +470,7 @@ impl<'a> Compiler<'a> {
         let mut value = Borrowed(value);
 
         match self.eval_constant(&value)? {
-            ConstResult::IsConstant |
-            ConstResult::IsRuntime => (),
+            ConstResult::IsConstant | ConstResult::IsRuntime => (),
             ConstResult::Partial(v) => value = Owned(v),
             ConstResult::Constant(v) => {
                 self.load_quoted_value(Owned(v))?;
@@ -484,8 +500,8 @@ impl<'a> Compiler<'a> {
                         } else if self.self_name == Some(name) {
                             () // This is handled later
                         } else if self.is_macro(name) {
-                            self.trace.push(TraceItem::CallMacro(
-                                self.ctx.scope().name(), name));
+                            self.trace
+                                .push(TraceItem::CallMacro(self.ctx.scope().name(), name));
 
                             self.macro_recursion += 1;
                             let v = self.expand_macro(name, &li[1..], &value)?;
@@ -501,21 +517,22 @@ impl<'a> Compiler<'a> {
                             return Ok(());
                         }
 
-                        self.trace.push(TraceItem::CallCode(
-                            self.ctx.scope().name(), name));
+                        self.trace
+                            .push(TraceItem::CallCode(self.ctx.scope().name(), name));
                     }
                     Value::List(_) => {
                         self.compile_value(fn_v)?;
                         self.push_instruction(Instruction::Push)?;
                         pushed_fn = true;
 
-                        self.trace.push(
-                            TraceItem::CallExpr(self.ctx.scope().name()));
+                        self.trace
+                            .push(TraceItem::CallExpr(self.ctx.scope().name()));
                     }
                     ref v => {
                         self.set_trace_expr(&value);
-                        return Err(From::from(
-                            CompileError::InvalidCallExpression(v.type_name())));
+                        return Err(From::from(CompileError::InvalidCallExpression(
+                            v.type_name(),
+                        )));
                     }
                 }
 
@@ -531,14 +548,13 @@ impl<'a> Compiler<'a> {
                 } else {
                     if let Value::Name(name) = *fn_v {
                         if self.self_name == Some(name) {
-                            self.push_instruction(
-                                Instruction::CallSelf(n_args))?;
+                            self.push_instruction(Instruction::CallSelf(n_args))?;
                         } else {
                             match get_system_fn(name) {
                                 Some(sys_fn) => {
                                     if !sys_fn.arity.accepts(n_args) {
                                         self.set_trace_expr(&value);
-                                        return Err(From::from(CompileError::ArityError{
+                                        return Err(From::from(CompileError::ArityError {
                                             name: name,
                                             expected: sys_fn.arity,
                                             found: n_args,
@@ -549,8 +565,7 @@ impl<'a> Compiler<'a> {
                                 }
                                 None => {
                                     let c = self.add_const(Owned(Value::Name(name)));
-                                    self.push_instruction(
-                                        Instruction::CallConst(c, n_args))?;
+                                    self.push_instruction(Instruction::CallConst(c, n_args))?;
                                 }
                             }
                         }
@@ -563,9 +578,8 @@ impl<'a> Compiler<'a> {
                 self.set_trace_expr(&value);
                 return Err(From::from(CompileError::UnbalancedComma));
             }
-            Value::Quasiquote(ref v, n) =>
-                self.compile_quasiquote(v, n)?,
-            _ => self.load_const_value(&value)?
+            Value::Quasiquote(ref v, n) => self.compile_quasiquote(v, n)?,
+            _ => self.load_const_value(&value)?,
         }
 
         Ok(())
@@ -594,18 +608,21 @@ impl<'a> Compiler<'a> {
         self.scope().contains_macro(name)
     }
 
-    fn expand_macro(&mut self, name: Name, args: &[Value], expr: &Value)
-            -> Result<Value, Error> {
+    fn expand_macro(&mut self, name: Name, args: &[Value], expr: &Value) -> Result<Value, Error> {
         if self.macro_recursion >= MAX_MACRO_RECURSION {
             self.set_trace_expr(expr);
             return Err(From::from(CompileError::MacroRecursionExceeded));
         }
 
-        let lambda = self.scope().get_macro(name)
+        let lambda = self
+            .scope()
+            .get_macro(name)
             .expect("macro not found in expand_macro");
 
-        execute_lambda(&self.ctx, lambda, args.to_vec())
-            .map_err(|e| { self.extend_global_trace(); e })
+        execute_lambda(&self.ctx, lambda, args.to_vec()).map_err(|e| {
+            self.extend_global_trace();
+            e
+        })
     }
 
     fn self_name(&self) -> Option<Name> {
@@ -622,48 +639,45 @@ impl<'a> Compiler<'a> {
 
     fn eval_constant(&mut self, value: &Value) -> Result<ConstResult, Error> {
         match *value {
-            Value::Name(name) => {
-                match self.get_constant(name) {
-                    Some(v) => Ok(ConstResult::Constant(v)),
-                    None => Ok(ConstResult::IsRuntime)
-                }
-            }
+            Value::Name(name) => match self.get_constant(name) {
+                Some(v) => Ok(ConstResult::Constant(v)),
+                None => Ok(ConstResult::IsRuntime),
+            },
             Value::List(ref li) => {
                 let name = match li[0] {
                     Value::Name(name) => name,
-                    _ => return Ok(ConstResult::IsRuntime)
+                    _ => return Ok(ConstResult::IsRuntime),
                 };
 
-                self.eval_constant_function(name, &li[1..])
-                    .map_err(|e| {
-                        self.set_trace_expr(value);
-                        e
-                    })
+                self.eval_constant_function(name, &li[1..]).map_err(|e| {
+                    self.set_trace_expr(value);
+                    e
+                })
             }
             Value::Quasiquote(ref v, n) => self.eval_constant_quasiquote(v, n),
-            Value::Comma(_, _) |
-            Value::CommaAt(_, _) => {
+            Value::Comma(_, _) | Value::CommaAt(_, _) => {
                 self.set_trace_expr(value);
                 Err(From::from(CompileError::UnbalancedComma))
             }
             Value::Quote(ref v, 1) => Ok(ConstResult::Constant((**v).clone())),
-            Value::Quote(ref v, n) =>
-                Ok(ConstResult::Constant((**v).clone().quote(n - 1))),
-            _ => Ok(ConstResult::IsConstant)
+            Value::Quote(ref v, n) => Ok(ConstResult::Constant((**v).clone().quote(n - 1))),
+            _ => Ok(ConstResult::IsConstant),
         }
     }
 
-    fn eval_constant_function(&mut self, name: Name, args: &[Value])
-            -> Result<ConstResult, Error> {
-        self.trace.push(TraceItem::CallCode(
-            self.ctx.scope().name(), name));
+    fn eval_constant_function(&mut self, name: Name, args: &[Value]) -> Result<ConstResult, Error> {
+        self.trace
+            .push(TraceItem::CallCode(self.ctx.scope().name(), name));
         let v = self.eval_constant_function_inner(name, args)?;
         self.trace.pop();
         Ok(v)
     }
 
-    fn eval_constant_function_inner(&mut self, name: Name, args: &[Value])
-            -> Result<ConstResult, Error> {
+    fn eval_constant_function_inner(
+        &mut self,
+        name: Name,
+        args: &[Value],
+    ) -> Result<ConstResult, Error> {
         let n_args = args.len();
 
         match name {
@@ -671,8 +685,9 @@ impl<'a> Compiler<'a> {
                 let mut cond = Borrowed(&args[0]);
 
                 match self.eval_constant(&cond)? {
-                    ConstResult::IsRuntime | ConstResult::Partial(_) =>
-                        return Ok(ConstResult::IsRuntime),
+                    ConstResult::IsRuntime | ConstResult::Partial(_) => {
+                        return Ok(ConstResult::IsRuntime)
+                    }
                     ConstResult::IsConstant => (),
                     ConstResult::Constant(v) => {
                         cond = Owned(v);
@@ -689,103 +704,96 @@ impl<'a> Compiler<'a> {
 
                 if cond {
                     match self.eval_constant(&args[1])? {
-                        ConstResult::IsConstant =>
-                            Ok(ConstResult::Constant(args[1].clone())),
-                        ConstResult::IsRuntime =>
-                            Ok(ConstResult::Partial(args[1].clone())),
-                        r => Ok(r)
+                        ConstResult::IsConstant => Ok(ConstResult::Constant(args[1].clone())),
+                        ConstResult::IsRuntime => Ok(ConstResult::Partial(args[1].clone())),
+                        r => Ok(r),
                     }
                 } else if n_args == 2 {
                     Ok(ConstResult::Constant(().into()))
                 } else {
                     match self.eval_constant(&args[2])? {
-                        ConstResult::IsConstant =>
-                            Ok(ConstResult::Constant(args[2].clone())),
-                        ConstResult::IsRuntime =>
-                            Ok(ConstResult::Partial(args[2].clone())),
-                        r => Ok(r)
+                        ConstResult::IsConstant => Ok(ConstResult::Constant(args[2].clone())),
+                        ConstResult::IsRuntime => Ok(ConstResult::Partial(args[2].clone())),
+                        r => Ok(r),
                     }
                 }
             }
-            standard_names::ADD if args.is_empty() =>
-                Ok(ConstResult::Constant(0.into())),
+            standard_names::ADD if args.is_empty() => Ok(ConstResult::Constant(0.into())),
             standard_names::ADD => fold_commutative::<FoldAdd>(self, name, args),
-            standard_names::SUB if args.len() >= 2 =>
-                fold_anticommutative::<FoldSub>(self, name, standard_names::ADD, args),
-            standard_names::MUL if args.is_empty() =>
-                Ok(ConstResult::Constant(1.into())),
+            standard_names::SUB if args.len() >= 2 => {
+                fold_anticommutative::<FoldSub>(self, name, standard_names::ADD, args)
+            }
+            standard_names::MUL if args.is_empty() => Ok(ConstResult::Constant(1.into())),
             standard_names::MUL => fold_commutative::<FoldMul>(self, name, args),
-            standard_names::DIV if args.len() >= 2 =>
-                fold_anticommutative::<FoldDiv>(self, name, standard_names::MUL, args),
-            standard_names::FLOOR_DIV if args.len() >= 2 =>
-                fold_anticommutative::<FoldFloorDiv>(self, name, standard_names::FLOOR, args),
-            _ if is_const_system_fn(name) =>
-                eval_system_fn(self, name, args),
-            _ => Ok(ConstResult::IsRuntime)
+            standard_names::DIV if args.len() >= 2 => {
+                fold_anticommutative::<FoldDiv>(self, name, standard_names::MUL, args)
+            }
+            standard_names::FLOOR_DIV if args.len() >= 2 => {
+                fold_anticommutative::<FoldFloorDiv>(self, name, standard_names::FLOOR, args)
+            }
+            _ if is_const_system_fn(name) => eval_system_fn(self, name, args),
+            _ => Ok(ConstResult::IsRuntime),
         }
     }
 
-    fn eval_constant_quasiquote(&mut self, value: &Value, depth: u32)
-            -> Result<ConstResult, Error> {
+    fn eval_constant_quasiquote(
+        &mut self,
+        value: &Value,
+        depth: u32,
+    ) -> Result<ConstResult, Error> {
         let v = match self.eval_constant_quasi_value(value, depth)? {
             ConstResult::IsConstant => value.clone(),
             ConstResult::Constant(v) => v,
-            res => return Ok(res)
+            res => return Ok(res),
         };
 
         match depth {
             1 => Ok(ConstResult::Constant(v)),
-            _ => Ok(ConstResult::Constant(v.quasiquote(depth - 1)))
+            _ => Ok(ConstResult::Constant(v.quasiquote(depth - 1))),
         }
     }
 
     /// Evaluates a quasiquote value into a constant expression.
-    fn eval_constant_quasi_value(&mut self, value: &Value, depth: u32)
-            -> Result<ConstResult, Error> {
+    fn eval_constant_quasi_value(
+        &mut self,
+        value: &Value,
+        depth: u32,
+    ) -> Result<ConstResult, Error> {
         match *value {
-            Value::List(ref li) =>
-                self.eval_constant_quasiquote_list(li, depth),
+            Value::List(ref li) => self.eval_constant_quasiquote_list(li, depth),
             Value::Comma(_, n) if n > depth => {
                 self.set_trace_expr(value);
                 Err(From::from(CompileError::UnbalancedComma))
             }
-            Value::Comma(ref v, n) if n == depth => {
-                match self.eval_constant(v)? {
-                    ConstResult::IsConstant => Ok(ConstResult::Constant((&**v).clone())),
-                    res => Ok(res)
-                }
-            }
-            Value::Comma(ref v, n) => {
-                match self.eval_constant_quasi_value(v, depth - n)? {
-                    ConstResult::Constant(v) =>
-                        Ok(ConstResult::Constant(v.comma(n))),
-                    res => Ok(res)
-                }
-            }
+            Value::Comma(ref v, n) if n == depth => match self.eval_constant(v)? {
+                ConstResult::IsConstant => Ok(ConstResult::Constant((&**v).clone())),
+                res => Ok(res),
+            },
+            Value::Comma(ref v, n) => match self.eval_constant_quasi_value(v, depth - n)? {
+                ConstResult::Constant(v) => Ok(ConstResult::Constant(v.comma(n))),
+                res => Ok(res),
+            },
             Value::CommaAt(_, _) => {
                 self.set_trace_expr(value);
                 Err(From::from(CompileError::InvalidCommaAt))
             }
-            Value::Quote(ref v, n) => {
-                match self.eval_constant_quasi_value(v, depth)? {
-                    ConstResult::Constant(v) =>
-                        Ok(ConstResult::Constant(v.quote(n))),
-                    res => Ok(res)
-                }
-            }
-            Value::Quasiquote(ref v, n) => {
-                match self.eval_constant_quasi_value(v, depth + n)? {
-                    ConstResult::Constant(v) =>
-                        Ok(ConstResult::Constant(v.quasiquote(n))),
-                    res => Ok(res)
-                }
-            }
-            _ => Ok(ConstResult::IsConstant)
+            Value::Quote(ref v, n) => match self.eval_constant_quasi_value(v, depth)? {
+                ConstResult::Constant(v) => Ok(ConstResult::Constant(v.quote(n))),
+                res => Ok(res),
+            },
+            Value::Quasiquote(ref v, n) => match self.eval_constant_quasi_value(v, depth + n)? {
+                ConstResult::Constant(v) => Ok(ConstResult::Constant(v.quasiquote(n))),
+                res => Ok(res),
+            },
+            _ => Ok(ConstResult::IsConstant),
         }
     }
 
-    fn eval_constant_quasiquote_list(&mut self, li: &[Value], depth: u32)
-            -> Result<ConstResult, Error> {
+    fn eval_constant_quasiquote_list(
+        &mut self,
+        li: &[Value],
+        depth: u32,
+    ) -> Result<ConstResult, Error> {
         let mut new_constant = false;
         let mut values = Vec::new();
 
@@ -799,7 +807,7 @@ impl<'a> Compiler<'a> {
                     let v = match self.eval_constant(v)? {
                         ConstResult::IsConstant => (**v).clone(),
                         ConstResult::Constant(v) => v,
-                        res => return Ok(res)
+                        res => return Ok(res),
                     };
 
                     if !new_constant {
@@ -817,40 +825,36 @@ impl<'a> Compiler<'a> {
                         }
                     }
                 }
-                Value::CommaAt(ref v, n) => {
-                    match self.eval_constant_quasi_value(v, depth - n)? {
-                        ConstResult::IsConstant => {
-                            if new_constant {
-                                values.push((**v).clone());
-                            }
+                Value::CommaAt(ref v, n) => match self.eval_constant_quasi_value(v, depth - n)? {
+                    ConstResult::IsConstant => {
+                        if new_constant {
+                            values.push((**v).clone());
                         }
-                        ConstResult::Constant(v) => {
-                            if !new_constant {
-                                values.extend(li[..i].iter().cloned());
-                            }
-                            new_constant = true;
-                            values.push(v);
-                        }
-                        res => return Ok(res)
                     }
-                }
-                _ => {
-                    match self.eval_constant_quasi_value(v, depth)? {
-                        ConstResult::IsConstant => {
-                            if new_constant {
-                                values.push(v.clone());
-                            }
+                    ConstResult::Constant(v) => {
+                        if !new_constant {
+                            values.extend(li[..i].iter().cloned());
                         }
-                        ConstResult::Constant(v) => {
-                            if !new_constant {
-                                values.extend(li[..i].iter().cloned());
-                            }
-                            new_constant = true;
-                            values.push(v);
-                        }
-                        res => return Ok(res)
+                        new_constant = true;
+                        values.push(v);
                     }
-                }
+                    res => return Ok(res),
+                },
+                _ => match self.eval_constant_quasi_value(v, depth)? {
+                    ConstResult::IsConstant => {
+                        if new_constant {
+                            values.push(v.clone());
+                        }
+                    }
+                    ConstResult::Constant(v) => {
+                        if !new_constant {
+                            values.extend(li[..i].iter().cloned());
+                        }
+                        new_constant = true;
+                        values.push(v);
+                    }
+                    res => return Ok(res),
+                },
             }
         }
 
@@ -861,17 +865,16 @@ impl<'a> Compiler<'a> {
         }
     }
 
-    fn compile_operator(&mut self, name: Name, args: &[Value], expr: &Value)
-            -> Result<(), Error> {
+    fn compile_operator(&mut self, name: Name, args: &[Value], expr: &Value) -> Result<(), Error> {
         let op = get_system_operator(name);
         let n_args = args.len() as u32;
 
-        self.trace.push(TraceItem::CallOperator(
-            self.ctx.scope().name(), name));
+        self.trace
+            .push(TraceItem::CallOperator(self.ctx.scope().name(), name));
 
         if !op.arity.accepts(n_args) {
             self.set_trace_expr(expr);
-            Err(From::from(CompileError::ArityError{
+            Err(From::from(CompileError::ArityError {
                 name: name,
                 expected: op.arity,
                 found: n_args,
@@ -888,8 +891,7 @@ impl<'a> Compiler<'a> {
         if self.check_quasi_const(value, depth)? {
             match depth {
                 1 => self.load_quoted_value(Borrowed(value))?,
-                _ => self.load_quoted_value(Owned(
-                    value.clone().quasiquote(depth - 1)))?
+                _ => self.load_quoted_value(Owned(value.clone().quasiquote(depth - 1)))?,
             }
         } else {
             self.compile_quasi_value(value, depth)?;
@@ -909,8 +911,7 @@ impl<'a> Compiler<'a> {
         }
 
         match *value {
-            Value::Comma(ref v, n) if n == depth =>
-                self.compile_value(v),
+            Value::Comma(ref v, n) if n == depth => self.compile_value(v),
             Value::Comma(_, n) | Value::CommaAt(_, n) if n > depth => {
                 self.set_trace_expr(value);
                 Err(From::from(CompileError::UnbalancedComma))
@@ -924,8 +925,7 @@ impl<'a> Compiler<'a> {
                 self.set_trace_expr(value);
                 Err(From::from(CompileError::InvalidCommaAt))
             }
-            Value::List(ref li) =>
-                self.compile_quasiquote_list(li, depth),
+            Value::List(ref li) => self.compile_quasiquote_list(li, depth),
             Value::Quote(ref v, n) => {
                 self.compile_quasi_value(v, depth)?;
                 self.push_instruction(Instruction::Quote(n))?;
@@ -936,8 +936,7 @@ impl<'a> Compiler<'a> {
                     match n {
                         1 => self.load_const_value(v)?,
                         _ => {
-                            let c = self.add_const(Owned(
-                                Value::Quasiquote(v.clone(), n - 1)));
+                            let c = self.add_const(Owned(Value::Quasiquote(v.clone(), n - 1)));
                             self.push_instruction(Instruction::Const(c))?;
                         }
                     }
@@ -956,7 +955,7 @@ impl<'a> Compiler<'a> {
                 }
             }
             // Handled by `if check_quasi_const { ... }` above
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
@@ -990,8 +989,7 @@ impl<'a> Compiler<'a> {
                 Value::CommaAt(ref v, n) => {
                     n_items += 1;
                     self.compile_quasi_value(v, depth - n)?;
-                    self.push_instruction(
-                        Instruction::CommaAt(depth - n))?;
+                    self.push_instruction(Instruction::CommaAt(depth - n))?;
                     self.push_instruction(Instruction::Push)?;
                 }
                 _ => {
@@ -1013,7 +1011,9 @@ impl<'a> Compiler<'a> {
 
         if n_lists > 1 {
             self.push_instruction(Instruction::CallSysArgs(
-                standard_names::CONCAT.get(), n_lists))?;
+                standard_names::CONCAT.get(),
+                n_lists,
+            ))?;
         }
 
         Ok(())
@@ -1034,17 +1034,15 @@ impl<'a> Compiler<'a> {
             }
             Value::Quasiquote(ref v, n) => self.check_quasi_const(v, depth + n),
             Value::Quote(ref v, _) => self.check_quasi_const(v, depth),
-            Value::Comma(_, n)
-            | Value::CommaAt(_, n) if n > depth => {
+            Value::Comma(_, n) | Value::CommaAt(_, n) if n > depth => {
                 self.set_trace_expr(value);
                 Err(From::from(CompileError::UnbalancedComma))
             }
-            Value::Comma(_, n)
-            | Value::CommaAt(_, n) if n == depth => Ok(false),
-            Value::Comma(ref v, n)
-            | Value::CommaAt(ref v, n) =>
-                self.check_quasi_const(v, depth - n),
-            _ => Ok(true)
+            Value::Comma(_, n) | Value::CommaAt(_, n) if n == depth => Ok(false),
+            Value::Comma(ref v, n) | Value::CommaAt(ref v, n) => {
+                self.check_quasi_const(v, depth - n)
+            }
+            _ => Ok(true),
         }
     }
 
@@ -1116,7 +1114,7 @@ impl<'a> Compiler<'a> {
             standard_names::ID if n_args == 1 => {
                 self.compile_value(&args[0])?;
             }
-            _ => return Ok(false)
+            _ => return Ok(false),
         }
 
         Ok(true)
@@ -1160,13 +1158,13 @@ impl<'a> Compiler<'a> {
         let lhs_const = match self.eval_constant(lhs)? {
             ConstResult::IsConstant => Some(Borrowed(lhs)),
             ConstResult::Constant(v) => Some(Owned(v)),
-            _ => None
+            _ => None,
         };
 
         let rhs_const = match self.eval_constant(rhs)? {
             ConstResult::IsConstant => Some(Borrowed(rhs)),
             ConstResult::Constant(v) => Some(Owned(v)),
-            _ => None
+            _ => None,
         };
 
         if let Some(rhs) = rhs_const {
@@ -1191,13 +1189,13 @@ impl<'a> Compiler<'a> {
         let lhs_const = match self.eval_constant(lhs)? {
             ConstResult::IsConstant => Some(Borrowed(lhs)),
             ConstResult::Constant(v) => Some(Owned(v)),
-            _ => None
+            _ => None,
         };
 
         let rhs_const = match self.eval_constant(rhs)? {
             ConstResult::IsConstant => Some(Borrowed(rhs)),
             ConstResult::Constant(v) => Some(Owned(v)),
-            _ => None
+            _ => None,
         };
 
         if let Some(rhs) = rhs_const {
@@ -1226,8 +1224,7 @@ impl<'a> Compiler<'a> {
                 self.compile_value(arg)?;
                 self.push_instruction(Instruction::Push)?;
             }
-            self.push_instruction(
-                Instruction::List(args.len() as u32))?;
+            self.push_instruction(Instruction::List(args.len() as u32))?;
         }
 
         Ok(())
@@ -1248,7 +1245,8 @@ impl<'a> Compiler<'a> {
         let bind_block = self.new_block();
         let final_block = self.new_block();
 
-        self.current_block().jump_to(JumpInstruction::JumpIfBound(pos), final_block);
+        self.current_block()
+            .jump_to(JumpInstruction::JumpIfBound(pos), final_block);
 
         self.use_next(bind_block);
         self.compile_value(value)?;
@@ -1267,8 +1265,7 @@ impl<'a> Compiler<'a> {
                 self.push_instruction(Instruction::Push)?;
             }
 
-            self.push_instruction(
-                Instruction::BuildClosure(n, captures.len() as u32))
+            self.push_instruction(Instruction::BuildClosure(n, captures.len() as u32))
         }
     }
 
@@ -1290,7 +1287,7 @@ impl<'a> Compiler<'a> {
                 self.push_instruction(Instruction::LoadC(n))?;
                 Ok(true)
             }
-            None => Ok(false)
+            None => Ok(false),
         }
     }
 
@@ -1320,9 +1317,7 @@ impl<'a> Compiler<'a> {
             Value::Unit => self.push_instruction(Instruction::Unit),
             Value::Bool(true) => self.push_instruction(Instruction::True),
             Value::Bool(false) => self.push_instruction(Instruction::False),
-            Value::Quote(ref v, 1) => {
-                self.load_quoted_value(Borrowed(v))
-            }
+            Value::Quote(ref v, 1) => self.load_quoted_value(Borrowed(v)),
             Value::Quote(ref v, n) => {
                 let v = Value::Quote(v.clone(), n - 1);
                 self.load_quoted_value(Owned(v))
@@ -1359,20 +1354,26 @@ impl<'a> Compiler<'a> {
         let _ = self.stack.drain(n..);
     }
 
-    fn write_call_sys(&mut self, name: Name, arity: Arity, n_args: u32) -> Result<(), CompileError> {
+    fn write_call_sys(
+        &mut self,
+        name: Name,
+        arity: Arity,
+        n_args: u32,
+    ) -> Result<(), CompileError> {
         match arity {
             Arity::Exact(n) => {
                 // The only stack_offset adjustment that's done manually.
                 self.stack_offset -= n;
                 self.push_instruction(Instruction::CallSys(name.get()))
             }
-            _ => self.push_instruction(
-                Instruction::CallSysArgs(name.get(), n_args))
+            _ => self.push_instruction(Instruction::CallSysArgs(name.get(), n_args)),
         }
     }
 
     fn current_block(&mut self) -> &mut CodeBlock {
-        self.blocks.get_mut(self.cur_block).expect("invalid cur_block")
+        self.blocks
+            .get_mut(self.cur_block)
+            .expect("invalid cur_block")
     }
 
     fn new_block(&mut self) -> u32 {
@@ -1399,32 +1400,28 @@ impl<'a> Compiler<'a> {
             Instruction::Push => {
                 self.stack_offset += 1;
             }
-            Instruction::BuildClosure(_, n) |
-            Instruction::List(n) |
-            Instruction::Skip(n) => {
+            Instruction::BuildClosure(_, n) | Instruction::List(n) | Instruction::Skip(n) => {
                 self.stack_offset -= n;
             }
             // CallSys is handled at the push site
             // to avoid duplicate get_system_fn call
-            Instruction::CallSysArgs(_, n) |
-            Instruction::CallSelf(n) |
-            Instruction::CallConst(_, n) |
-            Instruction::ApplyConst(_, n) |
-            Instruction::ApplySelf(n) => {
+            Instruction::CallSysArgs(_, n)
+            | Instruction::CallSelf(n)
+            | Instruction::CallConst(_, n)
+            | Instruction::ApplyConst(_, n)
+            | Instruction::ApplySelf(n) => {
                 self.stack_offset -= n;
             }
-            Instruction::Call(n) |
-            Instruction::Apply(n) => {
+            Instruction::Call(n) | Instruction::Apply(n) => {
                 self.stack_offset -= n + 1;
             }
             Instruction::Append => {
                 self.stack_offset -= 1;
             }
-            Instruction::Eq |
-            Instruction::NotEq => {
+            Instruction::Eq | Instruction::NotEq => {
                 self.stack_offset -= 1;
             }
-            _ => ()
+            _ => (),
         }
 
         self.current_block().push_instruction(instr)
@@ -1435,19 +1432,12 @@ fn is_const_system_fn(name: Name) -> bool {
     use name::standard_names::*;
 
     match name {
-        ADD | SUB | MUL | POW | DIV | FLOOR_DIV |
-        REM | SHL | SHR |
-        EQ | NOT_EQ | WEAK_EQ | WEAK_NE | LT | GT | LE | GE |
-        ZERO | MIN | MAX |
-        APPEND | ELT | CONCAT | JOIN | LEN | SLICE |
-        FIRST | SECOND | LAST | INIT | TAIL | LIST | REVERSE |
-        ABS | CEIL | FLOOR | ROUND | TRUNC | INT |
-        FLOAT | INF | NAN | DENOM | FRACT | NUMER | RAT | RECIP |
-        CHARS | STRING | PATH | BYTES |
-        ID | IS | IS_INSTANCE | NULL | TYPE_OF |
-        XOR | NOT
-            => true,
-        _ => false
+        ADD | SUB | MUL | POW | DIV | FLOOR_DIV | REM | SHL | SHR | EQ | NOT_EQ | WEAK_EQ
+        | WEAK_NE | LT | GT | LE | GE | ZERO | MIN | MAX | APPEND | ELT | CONCAT | JOIN | LEN
+        | SLICE | FIRST | SECOND | LAST | INIT | TAIL | LIST | REVERSE | ABS | CEIL | FLOOR
+        | ROUND | TRUNC | INT | FLOAT | INF | NAN | DENOM | FRACT | NUMER | RAT | RECIP | CHARS
+        | STRING | PATH | BYTES | ID | IS | IS_INSTANCE | NULL | TYPE_OF | XOR | NOT => true,
+        _ => false,
     }
 }
 
@@ -1460,9 +1450,12 @@ fn is_const_system_fn(name: Name) -> bool {
 /// `(- 1 foo 2 3)` -> `(- -4 foo)`
 ///
 /// `solo_name` is used in the case of `(foo value identity)`.
-fn fold_anticommutative<F: FoldOp>(compiler: &mut Compiler,
-        name: Name, solo_name: Name, args: &[Value])
-        -> Result<ConstResult, Error> {
+fn fold_anticommutative<F: FoldOp>(
+    compiler: &mut Compiler,
+    name: Name,
+    solo_name: Name,
+    args: &[Value],
+) -> Result<ConstResult, Error> {
     let mut args = args.iter();
     let mut new_args = Vec::new();
     let mut value = None;
@@ -1519,7 +1512,7 @@ fn fold_anticommutative<F: FoldOp>(compiler: &mut Compiler,
                     Some(F::fold_inv(&compiler.ctx, lhs, &rhs)?)
                 };
             }
-            None => value = Some(rhs.into_owned())
+            None => value = Some(rhs.into_owned()),
         }
     }
 
@@ -1552,8 +1545,11 @@ fn fold_anticommutative<F: FoldOp>(compiler: &mut Compiler,
 /// Fold constants for a commutative operation.
 ///
 /// e.g. `(+ 1 foo 2 3)` -> `(+ foo 6)`
-fn fold_commutative<F: FoldOp>(compiler: &mut Compiler, name: Name, args: &[Value])
-        -> Result<ConstResult, Error> {
+fn fold_commutative<F: FoldOp>(
+    compiler: &mut Compiler,
+    name: Name,
+    args: &[Value],
+) -> Result<ConstResult, Error> {
     let mut new_args = Vec::new();
     let mut value = None;
 
@@ -1580,7 +1576,7 @@ fn fold_commutative<F: FoldOp>(compiler: &mut Compiler, name: Name, args: &[Valu
 
         match value {
             Some(lhs) => value = Some(F::fold(&compiler.ctx, lhs, &rhs)?),
-            None => value = Some(rhs.into_owned())
+            None => value = Some(rhs.into_owned()),
         }
     }
 
@@ -1602,15 +1598,17 @@ fn fold_commutative<F: FoldOp>(compiler: &mut Compiler, name: Name, args: &[Valu
 
 /// Evaluates the named system function by calling it directly,
 /// if and only if all arguments are constant values.
-fn eval_system_fn(compiler: &mut Compiler, name: Name, args: &[Value])
-        -> Result<ConstResult, Error> {
-    let sys_fn = get_system_fn(name)
-        .expect("eval_system_fn got invalid name");
+fn eval_system_fn(
+    compiler: &mut Compiler,
+    name: Name,
+    args: &[Value],
+) -> Result<ConstResult, Error> {
+    let sys_fn = get_system_fn(name).expect("eval_system_fn got invalid name");
 
     let n_args = args.len() as u32;
 
     if !sys_fn.arity.accepts(n_args) {
-        return Err(From::from(CompileError::ArityError{
+        return Err(From::from(CompileError::ArityError {
             name: name,
             expected: sys_fn.arity,
             found: n_args,
@@ -1621,8 +1619,7 @@ fn eval_system_fn(compiler: &mut Compiler, name: Name, args: &[Value])
 
     for v in args {
         match compiler.eval_constant(v)? {
-            ConstResult::IsRuntime |
-            ConstResult::Partial(_) => return Ok(ConstResult::IsRuntime),
+            ConstResult::IsRuntime | ConstResult::Partial(_) => return Ok(ConstResult::IsRuntime),
             ConstResult::IsConstant => {
                 values.push(v.clone());
             }
@@ -1656,18 +1653,22 @@ fn block_returns<'a>(mut b: &'a CodeBlock, blocks: &'a [CodeBlock]) -> bool {
             (_, None) => return true,
             // This assumes that jumps cannot be cyclical.
             // Currently, the compiler does not emit cyclical jumps.
-            (Some((JumpInstruction::Jump, n)), _) |
-            (_, Some(n)) if blocks[n as usize].is_mostly_empty() => {
+            (Some((JumpInstruction::Jump, n)), _) | (_, Some(n))
+                if blocks[n as usize].is_mostly_empty() =>
+            {
                 b = &blocks[n as usize];
             }
-            _ => return false
+            _ => return false,
         }
     }
 }
 
 fn estimate_size(blocks: &[CodeBlock]) -> usize {
-    blocks.iter().map(|b| b.calculate_size(false))
-        .fold(0, |a, b| a + b) + 1 // Plus one for final Return
+    blocks
+        .iter()
+        .map(|b| b.calculate_size(false))
+        .fold(0, |a, b| a + b)
+        + 1 // Plus one for final Return
 }
 
 struct Operator {
@@ -1679,11 +1680,11 @@ type OperatorCallback = fn(&mut Compiler, args: &[Value]) -> Result<(), Error>;
 
 macro_rules! sys_op {
     ( $callback:ident, $arity:expr ) => {
-        Operator{
+        Operator {
             arity: $arity,
             callback: $callback,
         }
-    }
+    };
 }
 
 fn get_system_operator(name: Name) -> &'static Operator {
@@ -1796,14 +1797,15 @@ fn op_let(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
                     _ => {
                         compiler.set_trace_expr(v);
                         return Err(From::from(CompileError::SyntaxError(
-                            "expected list of 2 elements")))
+                            "expected list of 2 elements",
+                        )));
                     }
                 }
             }
         }
         ref v => {
             compiler.set_trace_expr(v);
-            return Err(From::from(CompileError::SyntaxError("expected list")))
+            return Err(From::from(CompileError::SyntaxError("expected list")));
         }
     }
 
@@ -1832,7 +1834,9 @@ fn op_define(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         Value::Name(name) => {
             // Replace operator item with more specific item
             compiler.trace.pop();
-            compiler.trace.push(TraceItem::Define(compiler.ctx.scope().name(), name));
+            compiler
+                .trace
+                .push(TraceItem::Define(compiler.ctx.scope().name(), name));
 
             let (doc, body) = extract_doc_string(args)?;
             test_define_name(compiler.scope(), name)?;
@@ -1851,15 +1855,16 @@ fn op_define(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
             // Replace operator item with more specific item
             compiler.trace.pop();
-            compiler.trace.push(TraceItem::Define(compiler.ctx.scope().name(), name));
+            compiler
+                .trace
+                .push(TraceItem::Define(compiler.ctx.scope().name(), name));
 
             test_define_name(compiler.scope(), name)?;
             let (doc, body) = extract_doc_string(args)?;
 
             let c = compiler.add_const(Owned(Value::Name(name)));
 
-            let (lambda, captures) = make_lambda(
-                compiler, Some(name), &li[1..], body, doc)?;
+            let (lambda, captures) = make_lambda(compiler, Some(name), &li[1..], body, doc)?;
 
             if compiler.is_top_level() && captures.is_empty() {
                 // Add top-level, non-capturing lambdas to global scope immediately.
@@ -1876,7 +1881,9 @@ fn op_define(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         }
         ref v => {
             compiler.set_trace_expr(v);
-            Err(From::from(CompileError::SyntaxError("expected name or list")))
+            Err(From::from(CompileError::SyntaxError(
+                "expected name or list",
+            )))
         }
     }
 }
@@ -1896,19 +1903,20 @@ fn op_macro(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     // Replace operator item with more specific item
     compiler.trace.pop();
-    compiler.trace.push(TraceItem::DefineMacro(
-        compiler.ctx.scope().name(), name));
+    compiler
+        .trace
+        .push(TraceItem::DefineMacro(compiler.ctx.scope().name(), name));
 
     let (doc, body) = extract_doc_string(args)?;
 
     test_define_name(compiler.scope(), name)?;
 
-    let (lambda, captures) = make_lambda(compiler,
-        Some(name), params, &body, doc)?;
+    let (lambda, captures) = make_lambda(compiler, Some(name), params, &body, doc)?;
 
     if !captures.is_empty() {
         return Err(From::from(CompileError::SyntaxError(
-            "macro lambda cannot enclose values")));
+            "macro lambda cannot enclose values",
+        )));
     }
 
     compiler.scope().add_macro(name, lambda);
@@ -1929,8 +1937,9 @@ fn op_struct(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     // Replace operator item with more specific item
     compiler.trace.pop();
-    compiler.trace.push(TraceItem::DefineStruct(
-        compiler.ctx.scope().name(), name));
+    compiler
+        .trace
+        .push(TraceItem::DefineStruct(compiler.ctx.scope().name(), name));
 
     let (doc, body) = extract_doc_string(args)?;
 
@@ -1951,7 +1960,8 @@ fn op_struct(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
                     _ => {
                         compiler.set_trace_expr(v);
                         return Err(From::from(CompileError::SyntaxError(
-                            "expected list of 2 elements")))
+                            "expected list of 2 elements",
+                        )));
                     }
                 }
             }
@@ -1990,16 +2000,20 @@ fn op_if(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
     let final_block = compiler.new_block();
 
     compiler.compile_value(&args[0])?;
-    compiler.current_block().jump_to(JumpInstruction::JumpIfNot, else_block);
+    compiler
+        .current_block()
+        .jump_to(JumpInstruction::JumpIfNot, else_block);
 
     compiler.use_next(then_block);
     compiler.compile_value(&args[1])?;
-    compiler.current_block().jump_to(JumpInstruction::Jump, final_block);
+    compiler
+        .current_block()
+        .jump_to(JumpInstruction::Jump, final_block);
 
     compiler.use_next(else_block);
     match args.get(2) {
         Some(value) => compiler.compile_value(value)?,
-        None => compiler.push_instruction(Instruction::Unit)?
+        None => compiler.push_instruction(Instruction::Unit)?,
     }
 
     compiler.use_next(final_block);
@@ -2021,7 +2035,9 @@ fn op_and(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         // the compiler from merging it with a previous instruction,
         // which might result in a different value, e.g. () for JumpIfNotNull.
         compiler.flush_instructions()?;
-        compiler.current_block().jump_to(JumpInstruction::JumpIfNot, last_block);
+        compiler
+            .current_block()
+            .jump_to(JumpInstruction::JumpIfNot, last_block);
 
         let block = compiler.new_block();
         compiler.use_next(block);
@@ -2047,7 +2063,9 @@ fn op_or(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         // the compiler from merging it with a previous instruction,
         // which might result in a different value, e.g. () for JumpIfNull.
         compiler.flush_instructions()?;
-        compiler.current_block().jump_to(JumpInstruction::JumpIf, last_block);
+        compiler
+            .current_block()
+            .jump_to(JumpInstruction::JumpIf, last_block);
 
         let block = compiler.new_block();
         compiler.use_next(block);
@@ -2092,7 +2110,8 @@ fn op_case(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
             _ => {
                 compiler.set_trace_expr(case);
                 return Err(From::from(CompileError::SyntaxError(
-                    "expected list of 2 elements")));
+                    "expected list of 2 elements",
+                )));
             }
         };
 
@@ -2105,16 +2124,20 @@ fn op_case(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
             Value::List(ref li) => {
                 for v in li {
                     match *v {
-                        Value::Unit => compiler.current_block().jump_to(
-                            JumpInstruction::JumpIfNull, code_begin),
-                        Value::Bool(true) => compiler.current_block().jump_to(
-                            JumpInstruction::JumpIf, code_begin),
-                        Value::Bool(false) => compiler.current_block().jump_to(
-                            JumpInstruction::JumpIfNot, code_begin),
+                        Value::Unit => compiler
+                            .current_block()
+                            .jump_to(JumpInstruction::JumpIfNull, code_begin),
+                        Value::Bool(true) => compiler
+                            .current_block()
+                            .jump_to(JumpInstruction::JumpIf, code_begin),
+                        Value::Bool(false) => compiler
+                            .current_block()
+                            .jump_to(JumpInstruction::JumpIfNot, code_begin),
                         ref v => {
                             let c = compiler.add_const(Borrowed(v));
-                            compiler.current_block().jump_to(
-                                JumpInstruction::JumpIfEqConst(c), code_begin);
+                            compiler
+                                .current_block()
+                                .jump_to(JumpInstruction::JumpIfEqConst(c), code_begin);
                         }
                     }
                     let b = compiler.new_block();
@@ -2123,19 +2146,24 @@ fn op_case(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
             }
             Value::Name(standard_names::ELSE) => {
                 else_case = true;
-                compiler.current_block().jump_to(JumpInstruction::Jump, code_begin);
+                compiler
+                    .current_block()
+                    .jump_to(JumpInstruction::Jump, code_begin);
             }
             ref v => {
                 compiler.set_trace_expr(v);
                 return Err(From::from(CompileError::SyntaxError(
-                    "expected list or `else`")));
+                    "expected list or `else`",
+                )));
             }
         }
 
         let prev_block = compiler.cur_block as u32;
         compiler.use_block(code_begin);
         compiler.compile_value(code)?;
-        compiler.current_block().jump_to(JumpInstruction::Jump, final_block);
+        compiler
+            .current_block()
+            .jump_to(JumpInstruction::Jump, final_block);
         let code_end = compiler.cur_block as u32;
         code_blocks.push((code_begin, code_end));
 
@@ -2146,7 +2174,9 @@ fn op_case(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     if !else_case {
         compiler.push_instruction(Instruction::Unit)?;
-        compiler.current_block().jump_to(JumpInstruction::Jump, final_block);
+        compiler
+            .current_block()
+            .jump_to(JumpInstruction::Jump, final_block);
     }
 
     for (begin, end) in code_blocks {
@@ -2181,7 +2211,8 @@ fn op_cond(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         if else_case {
             compiler.set_trace_expr(arg);
             return Err(From::from(CompileError::SyntaxError(
-                "unreachable condition")));
+                "unreachable condition",
+            )));
         }
 
         let case = match *arg {
@@ -2189,7 +2220,8 @@ fn op_cond(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
             _ => {
                 compiler.set_trace_expr(arg);
                 return Err(From::from(CompileError::SyntaxError(
-                    "expected list of 2 elements")));
+                    "expected list of 2 elements",
+                )));
             }
         };
 
@@ -2200,16 +2232,22 @@ fn op_cond(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
         if let Value::Name(standard_names::ELSE) = *cond {
             else_case = true;
-            compiler.current_block().jump_to(JumpInstruction::Jump, code_begin);
+            compiler
+                .current_block()
+                .jump_to(JumpInstruction::Jump, code_begin);
         } else {
             compiler.compile_value(cond)?;
-            compiler.current_block().jump_to(JumpInstruction::JumpIf, code_begin);
+            compiler
+                .current_block()
+                .jump_to(JumpInstruction::JumpIf, code_begin);
         }
 
         let prev_block = compiler.cur_block as u32;
         compiler.use_block(code_begin);
         compiler.compile_value(code)?;
-        compiler.current_block().jump_to(JumpInstruction::Jump, final_block);
+        compiler
+            .current_block()
+            .jump_to(JumpInstruction::Jump, final_block);
         let code_end = compiler.cur_block as u32;
         code_blocks.push((code_begin, code_end));
 
@@ -2220,7 +2258,9 @@ fn op_cond(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     if !else_case {
         compiler.push_instruction(Instruction::Unit)?;
-        compiler.current_block().jump_to(JumpInstruction::Jump, final_block);
+        compiler
+            .current_block()
+            .jump_to(JumpInstruction::Jump, final_block);
     }
 
     for (begin, end) in code_blocks {
@@ -2242,7 +2282,9 @@ fn op_cond(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 fn op_lambda(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
     // Replace operator item with more specific item
     compiler.trace.pop();
-    compiler.trace.push(TraceItem::DefineLambda(compiler.ctx.scope().name()));
+    compiler
+        .trace
+        .push(TraceItem::DefineLambda(compiler.ctx.scope().name()));
 
     let (doc, body) = extract_doc_string(args)?;
 
@@ -2255,8 +2297,7 @@ fn op_lambda(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         }
     };
 
-    let (lambda, captures) = make_lambda(
-        compiler, None, li, body, doc)?;
+    let (lambda, captures) = make_lambda(compiler, None, li, body, doc)?;
 
     let c = compiler.add_const(Owned(Value::Lambda(lambda)));
     compiler.load_lambda(c, &captures)?;
@@ -2279,7 +2320,8 @@ fn op_export(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         ref v => {
             compiler.set_trace_expr(v);
             return Err(From::from(CompileError::SyntaxError(
-                "expected list of names in `export`")));
+                "expected list of names in `export`",
+            )));
         }
     };
 
@@ -2305,12 +2347,16 @@ fn op_use(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     // Replace operator item with more specific item
     compiler.trace.pop();
-    compiler.trace.push(TraceItem::UseModule(compiler.ctx.scope().name(), mod_name));
+    compiler
+        .trace
+        .push(TraceItem::UseModule(compiler.ctx.scope().name(), mod_name));
 
     let ctx = compiler.ctx.clone();
     let mods = ctx.scope().modules();
-    let m = mods.load_module(mod_name, &ctx)
-        .map_err(|e| { compiler.extend_global_trace(); e })?;
+    let m = mods.load_module(mod_name, &ctx).map_err(|e| {
+        compiler.extend_global_trace();
+        e
+    })?;
 
     let mut imp_set = ImportSet::new(mod_name);
 
@@ -2321,13 +2367,13 @@ fn op_use(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
         }
         Value::Unit => (),
         Value::List(ref li) => {
-            import_names(mod_name, &mut imp_set,
-                compiler.scope(), &m.scope, li)?;
+            import_names(mod_name, &mut imp_set, compiler.scope(), &m.scope, li)?;
         }
         ref v => {
             compiler.set_trace_expr(v);
             return Err(From::from(CompileError::SyntaxError(
-                "expected list of names or `:all`")));
+                "expected list of names or `:all`",
+            )));
         }
     }
 
@@ -2360,8 +2406,9 @@ fn op_const(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     // Replace operator item with more specific item
     compiler.trace.pop();
-    compiler.trace.push(TraceItem::DefineConst(
-        compiler.ctx.scope().name(), name));
+    compiler
+        .trace
+        .push(TraceItem::DefineConst(compiler.ctx.scope().name(), name));
 
     let (doc, body) = extract_doc_string(args)?;
 
@@ -2375,12 +2422,11 @@ fn op_const(compiler: &mut Compiler, args: &[Value]) -> Result<(), Error> {
 
     match compiler.eval_constant(&value)? {
         ConstResult::IsConstant => (),
-        ConstResult::IsRuntime |
-        ConstResult::Partial(_) => {
+        ConstResult::IsRuntime | ConstResult::Partial(_) => {
             compiler.set_trace_expr(&value);
             return Err(From::from(CompileError::NotConstant(name)));
         }
-        ConstResult::Constant(v) => value = Owned(v)
+        ConstResult::Constant(v) => value = Owned(v),
     }
 
     compiler.add_constant(name, value.into_owned());
@@ -2414,16 +2460,21 @@ fn op_set_module_doc(compiler: &mut Compiler, args: &[Value]) -> Result<(), Erro
     })
 }
 
-fn import_names(mod_name: Name, imps: &mut ImportSet,
-        a: &GlobalScope, b: &GlobalScope, names: &[Value]) -> Result<(), CompileError> {
+fn import_names(
+    mod_name: Name,
+    imps: &mut ImportSet,
+    a: &GlobalScope,
+    b: &GlobalScope,
+    names: &[Value],
+) -> Result<(), CompileError> {
     each_import(names, |src, dest| {
         if !b.contains_name(src) {
-            return Err(CompileError::ImportError{
+            return Err(CompileError::ImportError {
                 module: mod_name,
                 name: src,
             });
         } else if !b.is_exported(src) {
-            return Err(CompileError::PrivacyError{
+            return Err(CompileError::PrivacyError {
                 module: mod_name,
                 name: src,
             });
@@ -2451,18 +2502,19 @@ fn import_names(mod_name: Name, imps: &mut ImportSet,
 }
 
 fn each_import<F>(items: &[Value], mut f: F) -> Result<(), CompileError>
-        where F: FnMut(Name, Name) -> Result<(), CompileError> {
+where
+    F: FnMut(Name, Name) -> Result<(), CompileError>,
+{
     let mut iter = items.iter();
 
     while let Some(item) = iter.next() {
         let (src, dest) = match *item {
             Value::Keyword(dest) => match iter.next() {
                 Some(&Value::Name(src)) => (src, dest),
-                _ => return Err(CompileError::SyntaxError(
-                    "expected name following keyword"))
+                _ => return Err(CompileError::SyntaxError("expected name following keyword")),
             },
             Value::Name(name) => (name, name),
-            _ => return Err(CompileError::SyntaxError("expected name or keyword"))
+            _ => return Err(CompileError::SyntaxError("expected name or keyword")),
         };
 
         f(src, dest)?;
@@ -2495,9 +2547,13 @@ fn test_define_name(scope: &GlobalScope, name: Name) -> Result<(), CompileError>
 
 /// Creates a `Lambda` object using scope and local values from the given compiler.
 /// Returns the `Lambda` object and the set of names captured by the lambda.
-fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
-        args: &[Value], body: &Value, doc: Option<&str>)
-        -> Result<(Lambda, Vec<Name>), Error> {
+fn make_lambda(
+    compiler: &mut Compiler,
+    name: Option<Name>,
+    args: &[Value],
+    body: &Value,
+    doc: Option<&str>,
+) -> Result<(Lambda, Vec<Name>), Error> {
     let mut params = Vec::new();
     let mut req_params = 0;
     let mut kw_params = Vec::new();
@@ -2517,11 +2573,11 @@ fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
                 match kw {
                     standard_names::KEY => {
                         if key {
-                            return Err(From::from(CompileError::SyntaxError(
-                                "duplicate `:key`")));
+                            return Err(From::from(CompileError::SyntaxError("duplicate `:key`")));
                         } else if optional {
                             return Err(From::from(CompileError::SyntaxError(
-                                "`:key` and `:optional` are mutually exclusive")));
+                                "`:key` and `:optional` are mutually exclusive",
+                            )));
                         }
                         key = true;
                         req_params = params.len() as u32;
@@ -2529,10 +2585,12 @@ fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
                     standard_names::OPTIONAL => {
                         if optional {
                             return Err(From::from(CompileError::SyntaxError(
-                                "duplicate `:optional`")));
+                                "duplicate `:optional`",
+                            )));
                         } else if key {
                             return Err(From::from(CompileError::SyntaxError(
-                                "`:key` and `:optional` are mutually exclusive")));
+                                "`:key` and `:optional` are mutually exclusive",
+                            )));
                         }
                         optional = true;
                         req_params = params.len() as u32;
@@ -2540,25 +2598,35 @@ fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
                     standard_names::REST => {
                         if key {
                             return Err(From::from(CompileError::SyntaxError(
-                                "`:key` and `:rest` are mutually exclusive")));
+                                "`:key` and `:rest` are mutually exclusive",
+                            )));
                         }
 
                         let arg = match iter.next() {
                             Some(arg) => arg,
-                            None => return Err(From::from(CompileError::SyntaxError(
-                                "expected name after `:rest`")))
+                            None => {
+                                return Err(From::from(CompileError::SyntaxError(
+                                    "expected name after `:rest`",
+                                )))
+                            }
                         };
 
                         rest = Some(get_name(compiler, arg)?);
 
                         match iter.next() {
-                            Some(_) => return Err(From::from(CompileError::SyntaxError(
-                                "extraneous token after `:rest` argument"))),
-                            None => break
+                            Some(_) => {
+                                return Err(From::from(CompileError::SyntaxError(
+                                    "extraneous token after `:rest` argument",
+                                )))
+                            }
+                            None => break,
                         }
                     }
-                    _ => return Err(From::from(CompileError::SyntaxError(
-                        "expected :key, :optional, or :rest")))
+                    _ => {
+                        return Err(From::from(CompileError::SyntaxError(
+                            "expected :key, :optional, or :rest",
+                        )))
+                    }
                 }
                 continue;
             }
@@ -2569,12 +2637,13 @@ fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
             ref v => {
                 compiler.set_trace_expr(v);
                 return Err(From::from(CompileError::SyntaxError(
-                    "expected name, keyword, or list of 2 elements")));
+                    "expected name, keyword, or list of 2 elements",
+                )));
             }
         };
 
-        let exists = params.iter().any(|&(n, _)| n == name) ||
-            kw_params.iter().any(|&(n, _)| n == name);
+        let exists =
+            params.iter().any(|&(n, _)| n == name) || kw_params.iter().any(|&(n, _)| n == name);
 
         if exists {
             compiler.set_trace_expr(v);
@@ -2584,7 +2653,8 @@ fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
         if default.is_some() && !(key || optional) {
             compiler.set_trace_expr(v);
             return Err(From::from(CompileError::SyntaxError(
-                "default value before `:optional` or `:key`")));
+                "default value before `:optional` or `:key`",
+            )));
         }
 
         if key {
@@ -2600,16 +2670,18 @@ fn make_lambda(compiler: &mut Compiler, name: Option<Name>,
 
     if key && kw_params.is_empty() {
         return Err(From::from(CompileError::SyntaxError(
-            "expected arguments after `:key`")));
+            "expected arguments after `:key`",
+        )));
     }
 
     if optional && req_params == params.len() as u32 {
         return Err(From::from(CompileError::SyntaxError(
-            "expected arguments after `:optional`")));
+            "expected arguments after `:optional`",
+        )));
     }
 
-    let (mut code, captures) = compile_lambda(compiler,
-        name, params, req_params, kw_params, rest, body)?;
+    let (mut code, captures) =
+        compile_lambda(compiler, name, params, req_params, kw_params, rest, body)?;
 
     if let Some(doc) = doc {
         code.flags |= code_flags::HAS_DOC_STRING;

--- a/src/ketos/completion.rs
+++ b/src/ketos/completion.rs
@@ -5,8 +5,7 @@ use scope::{GlobalScope, MasterScope};
 /// Returns a sorted list of possible name completions for the given prefix.
 ///
 /// Returns `None` if no possible completions exist.
-pub fn complete_name(word: &str, scope: &GlobalScope)
-        -> Option<Vec<String>> {
+pub fn complete_name(word: &str, scope: &GlobalScope) -> Option<Vec<String>> {
     let mut results = Vec::new();
 
     for name in MasterScope::names() {

--- a/src/ketos/const_fold.rs
+++ b/src/ketos/const_fold.rs
@@ -2,8 +2,9 @@
 
 use error::Error;
 use exec::{Context, ExecError};
-use function::{add_number, div_number, floor_div_number_step,
-    floor_number, sub_number, mul_number};
+use function::{
+    add_number, div_number, floor_div_number_step, floor_number, mul_number, sub_number,
+};
 use value::Value;
 
 /// Describes an operation that can be constant-folded.
@@ -17,7 +18,9 @@ pub trait FoldOp {
     }
 
     /// Returns whether a value is equal to an identity value.
-    fn is_identity(_: &Value) -> bool { false }
+    fn is_identity(_: &Value) -> bool {
+        false
+    }
 
     /// Folds the two constant values, returning the resulting value.
     fn fold(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error>;
@@ -29,7 +32,9 @@ pub trait FoldOp {
 
     /// Finalizes a constant value when all arguments have been constant
     /// expressions.
-    fn finish(value: Value) -> Result<Value, Error> { Ok(value) }
+    fn finish(value: Value) -> Result<Value, Error> {
+        Ok(value)
+    }
 }
 
 pub enum FoldAdd {}
@@ -39,14 +44,18 @@ pub enum FoldDiv {}
 pub enum FoldFloorDiv {}
 
 impl FoldOp for FoldAdd {
-    fn is_identity(v: &Value) -> bool { is_zero(v) }
+    fn is_identity(v: &Value) -> bool {
+        is_zero(v)
+    }
     fn fold(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error> {
         add_number(ctx, lhs, rhs)
     }
 }
 
 impl FoldOp for FoldSub {
-    fn is_identity(v: &Value) -> bool { is_zero(v) }
+    fn is_identity(v: &Value) -> bool {
+        is_zero(v)
+    }
     fn fold(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error> {
         sub_number(ctx, lhs, rhs)
     }
@@ -56,14 +65,18 @@ impl FoldOp for FoldSub {
 }
 
 impl FoldOp for FoldMul {
-    fn is_identity(v: &Value) -> bool { is_one(v) }
+    fn is_identity(v: &Value) -> bool {
+        is_one(v)
+    }
     fn fold(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error> {
         mul_number(ctx, lhs, rhs)
     }
 }
 
 impl FoldOp for FoldDiv {
-    fn is_identity(v: &Value) -> bool { is_one(v) }
+    fn is_identity(v: &Value) -> bool {
+        is_one(v)
+    }
     fn fold(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error> {
         div_number(ctx, lhs, rhs)
     }
@@ -73,7 +86,9 @@ impl FoldOp for FoldDiv {
 }
 
 impl FoldOp for FoldFloorDiv {
-    fn is_identity(v: &Value) -> bool { is_one(v) }
+    fn is_identity(v: &Value) -> bool {
+        is_one(v)
+    }
 
     fn fold(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error> {
         floor_div_number_step(ctx, lhs, rhs)
@@ -91,7 +106,7 @@ impl FoldOp for FoldFloorDiv {
 fn check_number(v: &Value) -> Result<(), ExecError> {
     match *v {
         Value::Float(_) | Value::Integer(_) | Value::Ratio(_) => Ok(()),
-        ref v => Err(ExecError::expected("number", v))
+        ref v => Err(ExecError::expected("number", v)),
     }
 }
 
@@ -102,20 +117,20 @@ fn check_number(v: &Value) -> Result<(), ExecError> {
 pub fn is_zero(v: &Value) -> bool {
     match *v {
         Value::Integer(ref i) => i.is_zero(),
-        _ => false
+        _ => false,
     }
 }
 
 pub fn is_negative_one(v: &Value) -> bool {
     match *v {
         Value::Integer(ref i) => i.to_i32() == Some(-1),
-        _ => false
+        _ => false,
     }
 }
 
 pub fn is_one(v: &Value) -> bool {
     match *v {
         Value::Integer(ref i) => i.is_one(),
-        _ => false
+        _ => false,
     }
 }

--- a/src/ketos/error.rs
+++ b/src/ketos/error.rs
@@ -112,7 +112,9 @@ mod test {
     }
 
     impl StdError for E {
-        fn description(&self) -> &str { "error" }
+        fn description(&self) -> &str {
+            "error"
+        }
     }
 
     #[test]

--- a/src/ketos/function.rs
+++ b/src/ketos/function.rs
@@ -35,7 +35,9 @@ pub struct SystemFn {
 }
 
 impl Clone for SystemFn {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl PartialEq for SystemFn {
@@ -49,7 +51,11 @@ pub type FunctionImpl = fn(&Context, &mut [Value]) -> Result<Value, Error>;
 
 macro_rules! sys_fn {
     ( $callback:path , $arity:expr , $doc:expr ) => {
-        SystemFn{arity: $arity, callback: $callback, doc: Some($doc)}
+        SystemFn {
+            arity: $arity,
+            callback: $callback,
+            doc: Some($doc),
+        }
     };
 }
 
@@ -58,193 +64,356 @@ macro_rules! sys_fn {
 /// These names must correspond exactly to the first `NUM_SYSTEM_FNS`
 /// standard names defined in `name.rs`.
 pub static SYSTEM_FNS: [SystemFn; NUM_SYSTEM_FNS] = [
-    sys_fn!(fn_add,         Min(0),
-"Returns the sum of all arguments.
+    sys_fn!(
+        fn_add,
+        Min(0),
+        "Returns the sum of all arguments.
 
-Given no arguments, returns the additive identity, `0`."),
-    sys_fn!(fn_sub,         Min(1),
-"Returns the cumulative difference between successive arguments."),
-    sys_fn!(fn_mul,         Min(0),
-"Returns the product of all arguments.
+Given no arguments, returns the additive identity, `0`."
+    ),
+    sys_fn!(
+        fn_sub,
+        Min(1),
+        "Returns the cumulative difference between successive arguments."
+    ),
+    sys_fn!(
+        fn_mul,
+        Min(0),
+        "Returns the product of all arguments.
 
-Given no arguments, returns the multiplicative identity, `1`."),
-    sys_fn!(fn_pow,         Exact(2),
-"Returns a base value raised to an exponent."),
-    sys_fn!(fn_div,         Min(1),
-"Returns the cumulative quotient of successive arguments."),
-    sys_fn!(fn_floor_div,   Min(1),
-"Returns the cumulative quotient of successive arguments,
-rounded toward negative infinity."),
-    sys_fn!(fn_rem,         Exact(2),
-"Returns the remainder of two arguments."),
-    sys_fn!(fn_shl,         Exact(2),
-"Returns an integer, bit shifted left by a given number."),
-    sys_fn!(fn_shr,         Exact(2),
-"Returns an integer, bit shifted right by a given number."),
-    sys_fn!(fn_eq,          Min(2),
-"Returns whether the given arguments compare equal to one another.
+Given no arguments, returns the multiplicative identity, `1`."
+    ),
+    sys_fn!(
+        fn_pow,
+        Exact(2),
+        "Returns a base value raised to an exponent."
+    ),
+    sys_fn!(
+        fn_div,
+        Min(1),
+        "Returns the cumulative quotient of successive arguments."
+    ),
+    sys_fn!(
+        fn_floor_div,
+        Min(1),
+        "Returns the cumulative quotient of successive arguments,
+rounded toward negative infinity."
+    ),
+    sys_fn!(fn_rem, Exact(2), "Returns the remainder of two arguments."),
+    sys_fn!(
+        fn_shl,
+        Exact(2),
+        "Returns an integer, bit shifted left by a given number."
+    ),
+    sys_fn!(
+        fn_shr,
+        Exact(2),
+        "Returns an integer, bit shifted right by a given number."
+    ),
+    sys_fn!(
+        fn_eq,
+        Min(2),
+        "Returns whether the given arguments compare equal to one another.
 
 Values of different types may not be compared. Attempts to do so will
-result in an error."),
-    sys_fn!(fn_ne,          Min(2),
-"Returns whether each given argument differs in value from each other argument.
+result in an error."
+    ),
+    sys_fn!(
+        fn_ne,
+        Min(2),
+        "Returns whether each given argument differs in value from each other argument.
 
 Values of different types may not be compared. Attempts to do so will
-result in an error."),
-    sys_fn!(fn_weak_eq,     Min(2),
-"Returns whether the given arguments compare equal to one another.
+result in an error."
+    ),
+    sys_fn!(
+        fn_weak_eq,
+        Min(2),
+        "Returns whether the given arguments compare equal to one another.
 
-Comparing values of different types will yield `false`."),
-    sys_fn!(fn_weak_ne,     Min(2),
-"Returns whether the given arguments compare not equal to one another.
+Comparing values of different types will yield `false`."
+    ),
+    sys_fn!(
+        fn_weak_ne,
+        Min(2),
+        "Returns whether the given arguments compare not equal to one another.
 
-Comparing values of different types will yield `true`."),
-    sys_fn!(fn_lt,          Min(2),
-"Returns whether each argument compares less than each successive argument.
+Comparing values of different types will yield `true`."
+    ),
+    sys_fn!(
+        fn_lt,
+        Min(2),
+        "Returns whether each argument compares less than each successive argument.
 
 Values of different types may not be compared. Attempts to do so will
-result in an error."),
-    sys_fn!(fn_gt,          Min(2),
-"Returns whether each argument compares greater than each successive argument.
+result in an error."
+    ),
+    sys_fn!(
+        fn_gt,
+        Min(2),
+        "Returns whether each argument compares greater than each successive argument.
 
 Values of different types may not be compared. Attempts to do so will
-result in an error."),
-    sys_fn!(fn_le,          Min(2),
-"Returns whether each argument compares less than or equal to each
+result in an error."
+    ),
+    sys_fn!(
+        fn_le,
+        Min(2),
+        "Returns whether each argument compares less than or equal to each
 successive argument.
 
 Values of different types may not be compared. Attempts to do so will
-result in an error."),
-    sys_fn!(fn_ge,          Min(2),
-"Returns whether each argument compares greater than or equal to each
+result in an error."
+    ),
+    sys_fn!(
+        fn_ge,
+        Min(2),
+        "Returns whether each argument compares greater than or equal to each
 successive argument.
 
 Values of different types may not be compared. Attempts to do so will
-result in an error."),
-    sys_fn!(fn_zero,        Min(1),
-"Returns whether all given values are equal to zero."),
-    sys_fn!(fn_max,         Min(1),
-"Returns the greatest value of given arguments."),
-    sys_fn!(fn_min,         Min(1),
-"Returns the least value of given arguments."),
-    sys_fn!(fn_append,      Min(1),
-"Append a series of elements to a given list."),
-    sys_fn!(fn_elt,         Exact(2),
-"Returns an element from a sequence, starting at zero index."),
-    sys_fn!(fn_concat,      Min(1),
-"Concatenates a series of sequences."),
-    sys_fn!(fn_join,        Min(1),
-"Joins a series of lists or strings and chars using a separator value."),
-    sys_fn!(fn_len,         Exact(1),
-"Returns the length of the given sequence.
+result in an error."
+    ),
+    sys_fn!(
+        fn_zero,
+        Min(1),
+        "Returns whether all given values are equal to zero."
+    ),
+    sys_fn!(
+        fn_max,
+        Min(1),
+        "Returns the greatest value of given arguments."
+    ),
+    sys_fn!(
+        fn_min,
+        Min(1),
+        "Returns the least value of given arguments."
+    ),
+    sys_fn!(
+        fn_append,
+        Min(1),
+        "Append a series of elements to a given list."
+    ),
+    sys_fn!(
+        fn_elt,
+        Exact(2),
+        "Returns an element from a sequence, starting at zero index."
+    ),
+    sys_fn!(fn_concat, Min(1), "Concatenates a series of sequences."),
+    sys_fn!(
+        fn_join,
+        Min(1),
+        "Joins a series of lists or strings and chars using a separator value."
+    ),
+    sys_fn!(
+        fn_len,
+        Exact(1),
+        "Returns the length of the given sequence.
 
-String length is in bytes rather than characters."),
-    sys_fn!(fn_slice,       Range(2, 3),
-"Returns a subsequence of a list or string."),
-    sys_fn!(fn_first,       Exact(1),
-"Returns the first element of the given list or string."),
-    sys_fn!(fn_second,      Exact(1),
-"Returns the second element of the given list."),
-    sys_fn!(fn_last,        Exact(1),
-"Returns the last element of the given list or string."),
-    sys_fn!(fn_init,        Exact(1),
-"Returns all but the last element of the given list or string."),
-    sys_fn!(fn_tail,        Exact(1),
-"Returns all but the first element of the given list or string."),
-    sys_fn!(fn_list,        Min(0),
-"Returns a list of values. In contrast with the `'(a b c ...)` list
-construction syntax, this function will evaluate each of its arguments."),
-    sys_fn!(fn_reverse,     Exact(1),
-"Returns a list in reverse order."),
-    sys_fn!(fn_abs,         Exact(1),
-"Returns the absolute value of the given numerical value."),
-    sys_fn!(fn_ceil,        Exact(1),
-"Returns a number value rounded toward positive infinity."),
-    sys_fn!(fn_floor,       Exact(1),
-"Returns a number value rounded toward negative infinity."),
-    sys_fn!(fn_round,       Exact(1),
-"Returns a number rounded to the nearest integer.
-Rounds half-way cases away from zero."),
-    sys_fn!(fn_trunc,       Exact(1),
-"Returns a number rounded toward zero."),
-    sys_fn!(fn_int,         Exact(1),
-"Truncates a float or ratio value and returns its whole portion as an integer.
+String length is in bytes rather than characters."
+    ),
+    sys_fn!(
+        fn_slice,
+        Range(2, 3),
+        "Returns a subsequence of a list or string."
+    ),
+    sys_fn!(
+        fn_first,
+        Exact(1),
+        "Returns the first element of the given list or string."
+    ),
+    sys_fn!(
+        fn_second,
+        Exact(1),
+        "Returns the second element of the given list."
+    ),
+    sys_fn!(
+        fn_last,
+        Exact(1),
+        "Returns the last element of the given list or string."
+    ),
+    sys_fn!(
+        fn_init,
+        Exact(1),
+        "Returns all but the last element of the given list or string."
+    ),
+    sys_fn!(
+        fn_tail,
+        Exact(1),
+        "Returns all but the first element of the given list or string."
+    ),
+    sys_fn!(
+        fn_list,
+        Min(0),
+        "Returns a list of values. In contrast with the `'(a b c ...)` list
+construction syntax, this function will evaluate each of its arguments."
+    ),
+    sys_fn!(fn_reverse, Exact(1), "Returns a list in reverse order."),
+    sys_fn!(
+        fn_abs,
+        Exact(1),
+        "Returns the absolute value of the given numerical value."
+    ),
+    sys_fn!(
+        fn_ceil,
+        Exact(1),
+        "Returns a number value rounded toward positive infinity."
+    ),
+    sys_fn!(
+        fn_floor,
+        Exact(1),
+        "Returns a number value rounded toward negative infinity."
+    ),
+    sys_fn!(
+        fn_round,
+        Exact(1),
+        "Returns a number rounded to the nearest integer.
+Rounds half-way cases away from zero."
+    ),
+    sys_fn!(fn_trunc, Exact(1), "Returns a number rounded toward zero."),
+    sys_fn!(
+        fn_int,
+        Exact(1),
+        "Truncates a float or ratio value and returns its whole portion as an integer.
 
-If the given value is infinite or `NaN`, an error will result."),
-    sys_fn!(fn_float,       Exact(1),
-"Returns the given value as a floating point value."),
-    sys_fn!(fn_inf,         Min(0),
-"Returns whether all given arguments are equal to positive or negative infinity.
+If the given value is infinite or `NaN`, an error will result."
+    ),
+    sys_fn!(
+        fn_float,
+        Exact(1),
+        "Returns the given value as a floating point value."
+    ),
+    sys_fn!(
+        fn_inf,
+        Min(0),
+        "Returns whether all given arguments are equal to positive or negative infinity.
 
-Given no arguments, returns the value of positive infinity."),
-    sys_fn!(fn_nan,         Min(0),
-"Returns whether all given arguments are equal to `NaN`.
+Given no arguments, returns the value of positive infinity."
+    ),
+    sys_fn!(
+        fn_nan,
+        Min(0),
+        "Returns whether all given arguments are equal to `NaN`.
 
-Given no arguments, returns the value of `NaN`."),
-    sys_fn!(fn_denom,       Exact(1),
-"Returns the denominator of a ratio."),
-    sys_fn!(fn_fract,       Exact(1),
-"Returns the fractional portion of a float or ratio."),
-    sys_fn!(fn_numer,       Exact(1),
-"Returns the numerator of a ratio."),
-    sys_fn!(fn_rat,         Range(1, 2),
-"Returns the given numerical value as a ratio."),
-    sys_fn!(fn_recip,       Exact(1),
-"Returns the reciprocal of the given numeric value.
+Given no arguments, returns the value of `NaN`."
+    ),
+    sys_fn!(fn_denom, Exact(1), "Returns the denominator of a ratio."),
+    sys_fn!(
+        fn_fract,
+        Exact(1),
+        "Returns the fractional portion of a float or ratio."
+    ),
+    sys_fn!(fn_numer, Exact(1), "Returns the numerator of a ratio."),
+    sys_fn!(
+        fn_rat,
+        Range(1, 2),
+        "Returns the given numerical value as a ratio."
+    ),
+    sys_fn!(
+        fn_recip,
+        Exact(1),
+        "Returns the reciprocal of the given numeric value.
 
-If the value is of type integer, the value returned will be a ratio."),
-    sys_fn!(fn_chars,       Exact(1),
-"Returns a string transformed into a list of characters."),
-    sys_fn!(fn_string,      Exact(1),
-"Returns an argument converted into a string."),
-    sys_fn!(fn_path,         Exact(1),
-"Returns an argument converted into a path."),
-    sys_fn!(fn_bytes,       Exact(1),
-"Returns an argument converted into a byte string."),
-    sys_fn!(fn_id,          Exact(1),
-"Returns the unmodified value of the argument received."),
-    sys_fn!(fn_is,          Exact(2),
-"    (is type value)
+If the value is of type integer, the value returned will be a ratio."
+    ),
+    sys_fn!(
+        fn_chars,
+        Exact(1),
+        "Returns a string transformed into a list of characters."
+    ),
+    sys_fn!(
+        fn_string,
+        Exact(1),
+        "Returns an argument converted into a string."
+    ),
+    sys_fn!(
+        fn_path,
+        Exact(1),
+        "Returns an argument converted into a path."
+    ),
+    sys_fn!(
+        fn_bytes,
+        Exact(1),
+        "Returns an argument converted into a byte string."
+    ),
+    sys_fn!(
+        fn_id,
+        Exact(1),
+        "Returns the unmodified value of the argument received."
+    ),
+    sys_fn!(
+        fn_is,
+        Exact(2),
+        "    (is type value)
 
 Returns whether a given expression matches the named type.
 
 `is` also accepts `'number` as a type name, which matches `integer`, `float`,
-and `ratio` type values."),
-    sys_fn!(fn_is_instance, Exact(2),
-"    (is-instance def value)
+and `ratio` type values."
+    ),
+    sys_fn!(
+        fn_is_instance,
+        Exact(2),
+        "    (is-instance def value)
 
 Returns whether a given struct value is an instance of
-the named struct definition."),
-    sys_fn!(fn_null,        Exact(1),
-"Returns whether the given value is unit, `()`."),
-    sys_fn!(fn_type_of,     Exact(1),
-"Returns a name representing the type of the given value."),
-    sys_fn!(fn_dot,         Exact(2),
-"    (. value field-name)
+the named struct definition."
+    ),
+    sys_fn!(
+        fn_null,
+        Exact(1),
+        "Returns whether the given value is unit, `()`."
+    ),
+    sys_fn!(
+        fn_type_of,
+        Exact(1),
+        "Returns a name representing the type of the given value."
+    ),
+    sys_fn!(
+        fn_dot,
+        Exact(2),
+        "    (. value field-name)
 
-Accesses a field from a struct value."),
-    sys_fn!(fn_dot_eq,      Min(1),
-"    (.= struct :field value)
+Accesses a field from a struct value."
+    ),
+    sys_fn!(
+        fn_dot_eq,
+        Min(1),
+        "    (.= struct :field value)
 
-Returns a new struct value with named fields replaced with new values."),
-    sys_fn!(fn_new,         Min(1),
-"    (new struct-def :field value)
+Returns a new struct value with named fields replaced with new values."
+    ),
+    sys_fn!(
+        fn_new,
+        Min(1),
+        "    (new struct-def :field value)
 
-Creates a struct value."),
-    sys_fn!(fn_format,      Min(1),
-"Returns a formatted string."),
-    sys_fn!(fn_print,       Min(1),
-"Prints a formatted string to `stdout`."),
-    sys_fn!(fn_println,     Min(1),
-"Prints a formatted string to `stdout`, followed by a newline."),
-    sys_fn!(fn_panic,       Range(0, 1),
-"Immediately interrupts execution upon evaluation.
+Creates a struct value."
+    ),
+    sys_fn!(fn_format, Min(1), "Returns a formatted string."),
+    sys_fn!(fn_print, Min(1), "Prints a formatted string to `stdout`."),
+    sys_fn!(
+        fn_println,
+        Min(1),
+        "Prints a formatted string to `stdout`, followed by a newline."
+    ),
+    sys_fn!(
+        fn_panic,
+        Range(0, 1),
+        "Immediately interrupts execution upon evaluation.
 
-It accepts an optional parameter describing the reason for the panic."),
-    sys_fn!(fn_xor,         Exact(2),
-"Returns the exclusive-or of the given boolean values."),
-    sys_fn!(fn_not,         Exact(1),
-"Returns the inverse of the given boolean value."),
+It accepts an optional parameter describing the reason for the panic."
+    ),
+    sys_fn!(
+        fn_xor,
+        Exact(2),
+        "Returns the exclusive-or of the given boolean values."
+    ),
+    sys_fn!(
+        fn_not,
+        Exact(1),
+        "Returns the inverse of the given boolean value."
+    ),
 ];
 
 /// Describes the number of arguments a function may accept.
@@ -278,7 +447,7 @@ impl fmt::Display for Arity {
                 write!(f, "{} or {} arguments", min, max)
             } else {
                 write!(f, "between {} and {} arguments", min, max)
-            }
+            },
         }
     }
 }
@@ -286,7 +455,11 @@ impl fmt::Display for Arity {
 // TODO: Should probably go into some utility module
 /// Returns the suitable plural suffix `""` or `"s"` for count `n`.
 pub fn plural(n: u32) -> &'static str {
-    if n == 1 { "" } else { "s" }
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
 }
 
 /// Represents a function implemented in Rust.
@@ -325,7 +498,7 @@ pub struct Lambda {
 impl Lambda {
     /// Creates a new `Lambda`.
     pub fn new(code: Rc<Code>, scope: &Scope) -> Lambda {
-        Lambda{
+        Lambda {
             code: code,
             scope: Rc::downgrade(scope),
             values: None,
@@ -334,7 +507,7 @@ impl Lambda {
 
     /// Creates a new `Lambda` enclosing a set of values.
     pub fn new_closure(code: Rc<Code>, scope: WeakScope, values: Box<[Value]>) -> Lambda {
-        Lambda{
+        Lambda {
             code: code,
             scope: scope,
             values: Some(Rc::new(values)),
@@ -367,14 +540,14 @@ fn get_float(v: &Value) -> Result<f64, ExecError> {
 fn get_keyword(v: &Value) -> Result<Name, ExecError> {
     match *v {
         Value::Keyword(name) => Ok(name),
-        ref v => Err(ExecError::expected("keyword", v))
+        ref v => Err(ExecError::expected("keyword", v)),
     }
 }
 
 fn get_name(v: &Value) -> Result<Name, ExecError> {
     match *v {
         Value::Name(name) => Ok(name),
-        ref v => Err(ExecError::expected("name", v))
+        ref v => Err(ExecError::expected("name", v)),
     }
 }
 
@@ -386,38 +559,37 @@ fn get_struct_def_for(scope: &Scope, v: &Value) -> Result<Rc<StructDef>, ExecErr
     match *v {
         Value::Struct(ref s) => Ok(s.def().clone()),
         ref fv @ Value::Foreign(_) => get_foreign_value_struct_def(scope, fv),
-        ref v => Err(ExecError::expected("struct", v))
+        ref v => Err(ExecError::expected("struct", v)),
     }
 }
 
 fn get_foreign_value_struct_def(scope: &Scope, v: &Value) -> Result<Rc<StructDef>, ExecError> {
     match *v {
-        Value::Foreign(ref fv) => {
-            scope.get_struct_def(fv.type_id())
-                .ok_or_else(|| ExecError::expected("struct", v))
-        }
-        _ => unreachable!()
+        Value::Foreign(ref fv) => scope
+            .get_struct_def(fv.type_id())
+            .ok_or_else(|| ExecError::expected("struct", v)),
+        _ => unreachable!(),
     }
 }
 
 fn get_struct_def(v: &Value) -> Result<&Rc<StructDef>, ExecError> {
     match *v {
         Value::StructDef(ref d) => Ok(d),
-        ref v => Err(ExecError::expected("struct-def", v))
+        ref v => Err(ExecError::expected("struct-def", v)),
     }
 }
 
 fn expect_integer(v: &Value) -> Result<(), ExecError> {
     match *v {
         Value::Integer(_) => Ok(()),
-        _ => Err(ExecError::expected("integer", v))
+        _ => Err(ExecError::expected("integer", v)),
     }
 }
 
 fn expect_number(v: &Value) -> Result<(), ExecError> {
     match *v {
         Value::Float(_) | Value::Integer(_) | Value::Ratio(_) => Ok(()),
-        _ => Err(ExecError::expected("number", v))
+        _ => Err(ExecError::expected("number", v)),
     }
 }
 
@@ -436,12 +608,10 @@ pub fn value_is(scope: &Scope, a: &Value, ty: Name) -> bool {
     use name::standard_names::*;
 
     match *a {
-        Value::Float(_) | Value::Integer(_) | Value::Ratio(_)
-            if ty == NUMBER => true,
+        Value::Float(_) | Value::Integer(_) | Value::Ratio(_) if ty == NUMBER => true,
         Value::Unit | Value::List(_) if ty == LIST => true,
-        Value::Foreign(ref a) =>
-            scope.with_name(ty, |name| a.is_type(name)),
-        _ => type_of(scope, a) == ty
+        Value::Foreign(ref a) => scope.with_name(ty, |name| a.is_type(name)),
+        _ => type_of(scope, a) == ty,
     }
 }
 
@@ -451,22 +621,30 @@ fn coerce_numbers(lhs: Value, rhs: &Value) -> Result<(Value, Cow<Value>), ExecEr
         | (lhs @ Value::Integer(_), rhs @ &Value::Integer(_))
         | (lhs @ Value::Ratio(_), rhs @ &Value::Ratio(_)) => (lhs, Borrowed(rhs)),
 
-        (Value::Float(lhs), &Value::Integer(ref i)) =>
-            (lhs.into(), Owned(i.to_f64().ok_or(ExecError::Overflow)?.into())),
-        (Value::Integer(ref i), rhs @ &Value::Float(_)) =>
-            (i.to_f64().ok_or(ExecError::Overflow)?.into(), Borrowed(rhs)),
+        (Value::Float(lhs), &Value::Integer(ref i)) => (
+            lhs.into(),
+            Owned(i.to_f64().ok_or(ExecError::Overflow)?.into()),
+        ),
+        (Value::Integer(ref i), rhs @ &Value::Float(_)) => {
+            (i.to_f64().ok_or(ExecError::Overflow)?.into(), Borrowed(rhs))
+        }
 
-        (ref mut lhs @ Value::Ratio(_), &Value::Integer(ref i)) =>
-            (lhs.take(), Owned(Ratio::from_integer(i.clone()).into())),
-        (Value::Integer(i), rhs @ &Value::Ratio(_)) =>
-            (Ratio::from_integer(i).into(), Borrowed(rhs)),
+        (ref mut lhs @ Value::Ratio(_), &Value::Integer(ref i)) => {
+            (lhs.take(), Owned(Ratio::from_integer(i.clone()).into()))
+        }
+        (Value::Integer(i), rhs @ &Value::Ratio(_)) => {
+            (Ratio::from_integer(i).into(), Borrowed(rhs))
+        }
 
-        (Value::Float(lhs), &Value::Ratio(ref r)) =>
-            (lhs.into(), Owned(r.to_f64().ok_or(ExecError::Overflow)?.into())),
-        (Value::Ratio(ref r), rhs @ &Value::Float(_)) =>
-            (r.to_f64().ok_or(ExecError::Overflow)?.into(), Borrowed(rhs)),
+        (Value::Float(lhs), &Value::Ratio(ref r)) => (
+            lhs.into(),
+            Owned(r.to_f64().ok_or(ExecError::Overflow)?.into()),
+        ),
+        (Value::Ratio(ref r), rhs @ &Value::Float(_)) => {
+            (r.to_f64().ok_or(ExecError::Overflow)?.into(), Borrowed(rhs))
+        }
 
-        (lhs, rhs) => (lhs, Borrowed(rhs))
+        (lhs, rhs) => (lhs, Borrowed(rhs)),
     };
 
     Ok((lhs, rhs))
@@ -515,7 +693,7 @@ pub fn add_number(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error
 
             Ok((a + b).into())
         }
-        (a, b) => Err(From::from(ExecError::TypeMismatch{
+        (a, b) => Err(From::from(ExecError::TypeMismatch {
             lhs: a.type_name(),
             rhs: b.type_name(),
         })),
@@ -546,7 +724,7 @@ pub fn neg_number(v: Value) -> Result<Value, Error> {
         Value::Float(f) => Ok((-f).into()),
         Value::Integer(i) => Ok((-i).into()),
         Value::Ratio(r) => Ok((-r).into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -570,10 +748,10 @@ pub fn sub_number(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error
 
             Ok((a - b).into())
         }
-        (a, b) => Err(From::from(ExecError::TypeMismatch{
+        (a, b) => Err(From::from(ExecError::TypeMismatch {
             lhs: a.type_name(),
             rhs: b.type_name(),
-        }))
+        })),
     }
 }
 
@@ -616,10 +794,10 @@ pub fn mul_number(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error
 
             Ok((a * b).into())
         }
-        (a, b) => Err(From::from(ExecError::TypeMismatch{
+        (a, b) => Err(From::from(ExecError::TypeMismatch {
             lhs: a.type_name(),
             rhs: b.type_name(),
-        }))
+        })),
     }
 }
 
@@ -694,19 +872,17 @@ fn check_bits(ctx: &Context, bits: usize) -> Result<(), RestrictError> {
 
 fn pow_number(ctx: &Context, lhs: Value, rhs: Value) -> Result<Value, Error> {
     match (&lhs, &rhs) {
-        (&Value::Ratio(ref a), &Value::Integer(ref b)) =>
-            return pow_ratio_integer(ctx, a, b),
-        (&Value::Ratio(ref a), &Value::Ratio(ref b)) if b.is_integer() =>
-            return pow_ratio_integer(ctx, a, b.numer()),
-        _ => ()
+        (&Value::Ratio(ref a), &Value::Integer(ref b)) => return pow_ratio_integer(ctx, a, b),
+        (&Value::Ratio(ref a), &Value::Ratio(ref b)) if b.is_integer() => {
+            return pow_ratio_integer(ctx, a, b.numer())
+        }
+        _ => (),
     }
 
     let (lhs, rhs) = coerce_numbers(lhs, &rhs)?;
 
     match (lhs, &*rhs) {
-        (Value::Float(a), &Value::Float(b)) => {
-            Ok(a.powf(b).into())
-        }
+        (Value::Float(a), &Value::Float(b)) => Ok(a.powf(b).into()),
         (Value::Integer(ref a), &Value::Integer(ref b)) => {
             if b.is_negative() {
                 let a = a.to_f64().ok_or(ExecError::Overflow)?;
@@ -723,7 +899,7 @@ fn pow_number(ctx: &Context, lhs: Value, rhs: Value) -> Result<Value, Error> {
 
             Ok(a.powf(b).into())
         }
-        (ref a, b) => Err(From::from(ExecError::TypeMismatch{
+        (ref a, b) => Err(From::from(ExecError::TypeMismatch {
             lhs: a.type_name(),
             rhs: b.type_name(),
         })),
@@ -789,14 +965,12 @@ fn floor_recip_number(v: Value) -> Result<Value, Error> {
             test_zero(i)?;
             Ok((Integer::one() / i).into())
         }
-        Value::Float(f) => {
-            Ok(f.recip().floor().into())
-        }
+        Value::Float(f) => Ok(f.recip().floor().into()),
         Value::Ratio(ref r) => {
             test_zero(r)?;
             Ok(r.recip().floor().into())
         }
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -805,9 +979,7 @@ pub fn div_number(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error
     let (lhs, rhs) = coerce_numbers(lhs, rhs)?;
 
     match (lhs, &*rhs) {
-        (Value::Float(a), &Value::Float(b)) => {
-            Ok((a / b).into())
-        }
+        (Value::Float(a), &Value::Float(b)) => Ok((a / b).into()),
         (Value::Integer(ref a), &Value::Integer(ref b)) => {
             test_zero(b)?;
             if a.is_multiple_of(b) {
@@ -827,10 +999,10 @@ pub fn div_number(ctx: &Context, lhs: Value, rhs: &Value) -> Result<Value, Error
 
             Ok((a / b).into())
         }
-        (a, b) => Err(From::from(ExecError::TypeMismatch{
+        (a, b) => Err(From::from(ExecError::TypeMismatch {
             lhs: a.type_name(),
             rhs: b.type_name(),
-        }))
+        })),
     }
 }
 
@@ -844,7 +1016,7 @@ pub fn floor_div_number_step(ctx: &Context, lhs: Value, rhs: &Value) -> Result<V
             test_zero(b)?;
             Ok((a / b).into())
         }
-        (lhs, rhs) => div_number(ctx, lhs, rhs)
+        (lhs, rhs) => div_number(ctx, lhs, rhs),
     }
 }
 
@@ -863,9 +1035,7 @@ fn rem_number(lhs: Value, rhs: &Value) -> Result<Value, Error> {
     let (lhs, rhs) = coerce_numbers(lhs, rhs)?;
 
     match (lhs, &*rhs) {
-        (Value::Float(a), &Value::Float(b)) => {
-            Ok((a % b).into())
-        }
+        (Value::Float(a), &Value::Float(b)) => Ok((a % b).into()),
         (Value::Integer(ref a), &Value::Integer(ref b)) => {
             test_zero(b)?;
             Ok((a % b).into())
@@ -874,10 +1044,10 @@ fn rem_number(lhs: Value, rhs: &Value) -> Result<Value, Error> {
             test_zero(b)?;
             Ok((a % b).into())
         }
-        (a, b) => Err(From::from(ExecError::TypeMismatch{
+        (a, b) => Err(From::from(ExecError::TypeMismatch {
             lhs: a.type_name(),
             rhs: b.type_name(),
-        }))
+        })),
     }
 }
 
@@ -894,16 +1064,14 @@ fn shl_integer(ctx: &Context, lhs: &Value, rhs: &Value) -> Result<Value, Error> 
     expect_integer(rhs)?;
 
     match (lhs, rhs) {
-        (&Value::Integer(ref a), &Value::Integer(ref b)) => {
-            match b.to_u32() {
-                Some(n) => {
-                    check_bits(ctx, a.bits() + n as usize)?;
-                    Ok((a << (n as usize)).into())
-                }
-                None => Err(From::from(ExecError::Overflow)),
+        (&Value::Integer(ref a), &Value::Integer(ref b)) => match b.to_u32() {
+            Some(n) => {
+                check_bits(ctx, a.bits() + n as usize)?;
+                Ok((a << (n as usize)).into())
             }
-        }
-        _ => unreachable!()
+            None => Err(From::from(ExecError::Overflow)),
+        },
+        _ => unreachable!(),
     }
 }
 
@@ -920,13 +1088,11 @@ fn shr_integer(lhs: &Value, rhs: &Value) -> Result<Value, Error> {
     expect_integer(rhs)?;
 
     match (lhs, rhs) {
-        (&Value::Integer(ref a), &Value::Integer(ref b)) => {
-            match b.to_u32() {
-                Some(n) => Ok((a >> (n as usize)).into()),
-                None => Err(From::from(ExecError::Overflow)),
-            }
-        }
-        _ => unreachable!()
+        (&Value::Integer(ref a), &Value::Integer(ref b)) => match b.to_u32() {
+            Some(n) => Ok((a >> (n as usize)).into()),
+            None => Err(From::from(ExecError::Overflow)),
+        },
+        _ => unreachable!(),
     }
 }
 
@@ -977,7 +1143,7 @@ fn fn_ne(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 fn fn_weak_eq(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match fn_eq(ctx, args) {
         Ok(v) => Ok(v),
-        Err(_) => Ok(false.into())
+        Err(_) => Ok(false.into()),
     }
 }
 
@@ -987,7 +1153,7 @@ fn fn_weak_eq(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 fn fn_weak_ne(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match fn_ne(ctx, args) {
         Ok(v) => Ok(v),
-        Err(_) => Ok(true.into())
+        Err(_) => Ok(true.into()),
     }
 }
 
@@ -1086,7 +1252,7 @@ fn fn_zero(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
             Value::Float(a) => a == 0.0,
             Value::Integer(ref a) => a.is_zero(),
             Value::Ratio(ref a) => a.is_zero(),
-            ref v => return Err(From::from(ExecError::expected("number", v)))
+            ref v => return Err(From::from(ExecError::expected("number", v))),
         };
 
         if !is_zero {
@@ -1106,7 +1272,7 @@ fn fn_xor(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match (a, b) {
         (&Value::Bool(a), &Value::Bool(b)) => Ok((a ^ b).into()),
         (&Value::Bool(_), b) => Err(From::from(ExecError::expected("bool", b))),
-        (a, _) => Err(From::from(ExecError::expected("bool", a)))
+        (a, _) => Err(From::from(ExecError::expected("bool", a))),
     }
 }
 
@@ -1114,7 +1280,7 @@ fn fn_xor(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 fn fn_not(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0] {
         Value::Bool(a) => Ok((!a).into()),
-        ref v => Err(From::from(ExecError::expected("bool", v)))
+        ref v => Err(From::from(ExecError::expected("bool", v))),
     }
 }
 
@@ -1151,7 +1317,7 @@ fn fn_is_instance(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 fn fn_null(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     let is_null = match args[0] {
         Value::Unit => true,
-        _ => false
+        _ => false,
     };
 
     Ok(is_null.into())
@@ -1180,10 +1346,10 @@ fn type_of(scope: &Scope, v: &Value) -> Name {
         Value::List(_) => LIST,
         Value::Function(_) => FUNCTION,
         Value::Lambda(_) => LAMBDA,
-        Value::Quasiquote(_, _) |
-        Value::Comma(_, _) |
-        Value::CommaAt(_, _) |
-        Value::Quote(_, _) => OBJECT,
+        Value::Quasiquote(_, _)
+        | Value::Comma(_, _)
+        | Value::CommaAt(_, _)
+        | Value::Quote(_, _) => OBJECT,
         Value::Foreign(ref a) => scope.add_name(a.type_name()),
     }
 }
@@ -1224,7 +1390,7 @@ fn fn_dot_eq(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 
         let value = match iter.next() {
             Some(v) => v.take(),
-            None => return Err(From::from(ExecError::OddKeywordParams))
+            None => return Err(From::from(ExecError::OddKeywordParams)),
         };
 
         if fields.iter().any(|&(n, _)| n == name) {
@@ -1234,7 +1400,8 @@ fn fn_dot_eq(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         fields.push((name, value));
     }
 
-    def.def().replace_fields(ctx.scope(), &def, value, &mut fields)
+    def.def()
+        .replace_fields(ctx.scope(), &def, value, &mut fields)
 }
 
 /// `new` creates a struct value.
@@ -1253,7 +1420,7 @@ fn fn_new(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 
         let value = match iter.next() {
             Some(value) => value.take(),
-            None => return Err(From::from(ExecError::OddKeywordParams))
+            None => return Err(From::from(ExecError::OddKeywordParams)),
         };
 
         if fields.iter().any(|&(n, _)| n == name) {
@@ -1312,7 +1479,7 @@ fn fn_append(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     let mut v = match args[0].take() {
         Value::Unit => Vec::new(),
         Value::List(li) => li.into_vec(),
-        ref v => return Err(From::from(ExecError::expected("list", v)))
+        ref v => return Err(From::from(ExecError::expected("list", v))),
     };
 
     v.extend(args[1..].iter_mut().map(|v| v.take()));
@@ -1332,12 +1499,16 @@ fn fn_elt(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     let idx = usize::from_value_ref(idx)?;
 
     match *li {
-        Value::List(ref li) => li.get(idx).cloned()
+        Value::List(ref li) => li
+            .get(idx)
+            .cloned()
             .ok_or(From::from(ExecError::OutOfBounds(idx))),
-        Value::Bytes(ref b) => b.get(idx).cloned()
+        Value::Bytes(ref b) => b
+            .get(idx)
+            .cloned()
             .map(|b| b.into())
             .ok_or(From::from(ExecError::OutOfBounds(idx))),
-        ref v => Err(From::from(ExecError::expected("indexable sequence", v)))
+        ref v => Err(From::from(ExecError::expected("indexable sequence", v))),
     }
 }
 
@@ -1354,7 +1525,7 @@ fn fn_concat(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Char(_) | Value::String(_) => concat_string(args),
         Value::Bytes(_) => concat_bytes(args),
         Value::Path(_) => concat_path(args),
-        ref v => Err(From::from(ExecError::expected("list or string", v)))
+        ref v => Err(From::from(ExecError::expected("list or string", v))),
     }
 }
 
@@ -1369,7 +1540,7 @@ fn concat_list(args: &mut [Value]) -> Result<Value, Error> {
         match arg.take() {
             Value::Unit => (),
             Value::List(li) => v.extend(li.into_vec()),
-            ref v => return Err(From::from(ExecError::expected("list", v)))
+            ref v => return Err(From::from(ExecError::expected("list", v))),
         }
     }
 
@@ -1387,7 +1558,7 @@ fn concat_string(args: &mut [Value]) -> Result<Value, Error> {
         match *arg {
             Value::Char(ch) => res.push(ch),
             Value::String(ref s) => res.push_str(s),
-            ref v => return Err(From::from(ExecError::expected("char or string", v)))
+            ref v => return Err(From::from(ExecError::expected("char or string", v))),
         }
     }
 
@@ -1445,7 +1616,7 @@ fn fn_join(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::String(ref s) if s.is_empty() => concat_string(rest),
         Value::String(ref s) => join_string(s, rest),
         Value::Bytes(ref s) => join_bytes(s, rest),
-        ref v => Err(From::from(ExecError::expected("list or string", v)))
+        ref v => Err(From::from(ExecError::expected("list or string", v))),
     }
 }
 
@@ -1456,7 +1627,7 @@ fn join_list(sep: &[Value], args: &mut [Value]) -> Result<Value, Error> {
         match first.take() {
             Value::Unit => (),
             Value::List(li) => v.extend(li.into_vec()),
-            ref v => return Err(From::from(ExecError::expected("list", v)))
+            ref v => return Err(From::from(ExecError::expected("list", v))),
         }
 
         for arg in rest {
@@ -1465,7 +1636,7 @@ fn join_list(sep: &[Value], args: &mut [Value]) -> Result<Value, Error> {
             match arg.take() {
                 Value::Unit => (),
                 Value::List(li) => v.extend(li.into_vec()),
-                ref v => return Err(From::from(ExecError::expected("list", v)))
+                ref v => return Err(From::from(ExecError::expected("list", v))),
             }
         }
     }
@@ -1480,7 +1651,7 @@ fn join_string(sep: &str, args: &mut [Value]) -> Result<Value, Error> {
         match *value {
             Value::Char(ch) => res.push(ch),
             Value::String(ref s) => res.push_str(s),
-            ref v => return Err(From::from(ExecError::expected("char or string", v)))
+            ref v => return Err(From::from(ExecError::expected("char or string", v))),
         }
 
         for arg in &args[1..] {
@@ -1488,7 +1659,7 @@ fn join_string(sep: &str, args: &mut [Value]) -> Result<Value, Error> {
             match *arg {
                 Value::Char(ch) => res.push(ch),
                 Value::String(ref s) => res.push_str(s),
-                ref v => return Err(From::from(ExecError::expected("char or string", v)))
+                ref v => return Err(From::from(ExecError::expected("char or string", v))),
             }
         }
     }
@@ -1522,7 +1693,7 @@ fn fn_len(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::List(ref li) => li.len(),
         Value::String(ref s) => s.len(),
         Value::Bytes(ref b) => b.len(),
-        ref v => return Err(From::from(ExecError::expected("sequence", v)))
+        ref v => return Err(From::from(ExecError::expected("sequence", v))),
     };
 
     Ok(n.into())
@@ -1567,7 +1738,7 @@ fn fn_slice(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
                     Ok(b.slice(begin..).into())
                 }
             }
-            ref v => Err(From::from(ExecError::expected("list or string", v)))
+            ref v => Err(From::from(ExecError::expected("list or string", v))),
         }
     } else {
         let end = usize::from_value_ref(&args[2])?;
@@ -1620,7 +1791,7 @@ fn fn_slice(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
                     Ok(b.slice(begin..end).into())
                 }
             }
-            ref v => Err(From::from(ExecError::expected("list or string", v)))
+            ref v => Err(From::from(ExecError::expected("list or string", v))),
         }
     }
 }
@@ -1633,9 +1804,11 @@ fn fn_first(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 /// `second` returns the second element of the given list.
 fn fn_second(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0] {
-        Value::List(ref mut li) => li.get(1).cloned()
+        Value::List(ref mut li) => li
+            .get(1)
+            .cloned()
             .ok_or(From::from(ExecError::OutOfBounds(1))),
-        ref v => Err(From::from(ExecError::expected("list", v)))
+        ref v => Err(From::from(ExecError::expected("list", v))),
     }
 }
 
@@ -1663,13 +1836,13 @@ pub fn first(v: &Value) -> Result<Value, Error> {
         Value::List(ref li) => Ok(li[0].clone()),
         Value::String(ref s) => match s.chars().next() {
             Some(ch) => Ok(ch.into()),
-            None => Err(From::from(ExecError::OutOfBounds(0)))
+            None => Err(From::from(ExecError::OutOfBounds(0))),
         },
         Value::Bytes(ref b) => match b.iter().next() {
             Some(&b) => Ok(b.into()),
-            None => Err(From::from(ExecError::OutOfBounds(0)))
+            None => Err(From::from(ExecError::OutOfBounds(0))),
         },
-        ref v => Err(From::from(ExecError::expected("sequence", v)))
+        ref v => Err(From::from(ExecError::expected("sequence", v))),
     }
 }
 
@@ -1681,13 +1854,13 @@ pub fn last(v: &Value) -> Result<Value, Error> {
         Value::List(ref li) => Ok(li.last().cloned().unwrap()),
         Value::String(ref s) => match s.chars().next_back() {
             Some(ch) => Ok(ch.into()),
-            None => Err(From::from(ExecError::OutOfBounds(0)))
+            None => Err(From::from(ExecError::OutOfBounds(0))),
         },
         Value::Bytes(ref b) => match b.iter().next_back() {
             Some(&b) => Ok(b.into()),
-            None => Err(From::from(ExecError::OutOfBounds(0)))
+            None => Err(From::from(ExecError::OutOfBounds(0))),
         },
-        ref v => Err(From::from(ExecError::expected("sequence", v)))
+        ref v => Err(From::from(ExecError::expected("sequence", v))),
     }
 }
 
@@ -1705,7 +1878,7 @@ pub fn init(v: &Value) -> Result<Value, Error> {
 
             match chars.next_back() {
                 Some((idx, _)) => Ok(s.slice(..idx).into()),
-                None => Err(From::from(ExecError::OutOfBounds(0)))
+                None => Err(From::from(ExecError::OutOfBounds(0))),
             }
         }
         Value::Bytes(ref b) => {
@@ -1716,7 +1889,7 @@ pub fn init(v: &Value) -> Result<Value, Error> {
                 Ok(b.slice(..len - 1).into())
             }
         }
-        ref v => Err(From::from(ExecError::expected("sequence", v)))
+        ref v => Err(From::from(ExecError::expected("sequence", v))),
     }
 }
 
@@ -1725,15 +1898,13 @@ pub fn init(v: &Value) -> Result<Value, Error> {
 /// Returns an error in case of an empty list or string.
 pub fn tail(v: &Value) -> Result<Value, Error> {
     match *v {
-        Value::List(ref li) => {
-            Ok(li.slice(1..).into())
-        }
+        Value::List(ref li) => Ok(li.slice(1..).into()),
         Value::String(ref s) => {
             let mut chars = s.chars();
 
             match chars.next() {
                 Some(ch) => Ok(s.slice(ch.len_utf8()..).into()),
-                None => Err(From::from(ExecError::OutOfBounds(0)))
+                None => Err(From::from(ExecError::OutOfBounds(0))),
             }
         }
         Value::Bytes(ref b) => {
@@ -1743,7 +1914,7 @@ pub fn tail(v: &Value) -> Result<Value, Error> {
                 Ok(b.slice(1..).into())
             }
         }
-        ref v => Err(From::from(ExecError::expected("sequence", v)))
+        ref v => Err(From::from(ExecError::expected("sequence", v))),
     }
 }
 
@@ -1755,8 +1926,7 @@ pub fn tail(v: &Value) -> Result<Value, Error> {
 /// (list (foo) (+ 1 2 3))
 /// ```
 fn fn_list(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
-    Ok(args.iter_mut().map(|v| v.take())
-        .collect::<Vec<_>>().into())
+    Ok(args.iter_mut().map(|v| v.take()).collect::<Vec<_>>().into())
 }
 
 /// `reverse` returns a list in reverse order.
@@ -1768,7 +1938,7 @@ fn fn_reverse(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
             li.reverse();
             Ok(li.into())
         }
-        ref v => Err(From::from(ExecError::expected("list", v)))
+        ref v => Err(From::from(ExecError::expected("list", v))),
     }
 }
 
@@ -1778,7 +1948,7 @@ fn fn_abs(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => Ok(f.abs().into()),
         Value::Integer(ref i) => Ok(i.abs().into()),
         Value::Ratio(ref r) => Ok(r.abs().into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1788,7 +1958,7 @@ fn fn_ceil(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => Ok(f.ceil().into()),
         Value::Integer(i) => Ok(i.into()),
         Value::Ratio(ref r) => Ok(r.ceil().into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1803,7 +1973,7 @@ pub fn floor_number(v: Value) -> Result<Value, Error> {
         Value::Float(f) => Ok(f.floor().into()),
         Value::Integer(i) => Ok(i.into()),
         Value::Ratio(ref r) => Ok(r.floor().into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1814,7 +1984,7 @@ fn fn_round(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => Ok(f.round().into()),
         Value::Integer(i) => Ok(i.into()),
         Value::Ratio(ref r) => Ok(r.round().into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1824,7 +1994,7 @@ fn fn_trunc(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => Ok(f.trunc().into()),
         Value::Integer(i) => Ok(i.into()),
         Value::Ratio(ref r) => Ok(r.trunc().into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1836,11 +2006,12 @@ fn fn_int(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => match f {
             f if f.is_infinite() || f.is_nan() => Err(From::from(ExecError::Overflow)),
             f => Integer::from_f64(f)
-                .map(Value::Integer).ok_or(From::from(ExecError::Overflow)),
+                .map(Value::Integer)
+                .ok_or(From::from(ExecError::Overflow)),
         },
         Value::Integer(i) => Ok(i.into()),
         Value::Ratio(ref r) => Ok(r.to_integer().into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1850,7 +2021,7 @@ fn fn_float(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => Ok(f.into()),
         Value::Integer(ref i) => Ok(i.to_f64().ok_or(ExecError::Overflow)?.into()),
         Value::Ratio(ref r) => Ok(r.to_f64().ok_or(ExecError::Overflow)?.into()),
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1897,7 +2068,7 @@ fn fn_denom(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0] {
         Value::Integer(_) => Ok(Integer::one().into()),
         Value::Ratio(ref r) => Ok(r.denom().clone().into()),
-        ref v => Err(From::from(ExecError::expected("integer or ratio", v)))
+        ref v => Err(From::from(ExecError::expected("integer or ratio", v))),
     }
 }
 
@@ -1906,7 +2077,7 @@ fn fn_fract(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0] {
         Value::Float(f) => Ok(f.fract().into()),
         Value::Ratio(ref r) => Ok(r.fract().into()),
-        ref v => Err(From::from(ExecError::expected("float or ratio", v)))
+        ref v => Err(From::from(ExecError::expected("float or ratio", v))),
     }
 }
 
@@ -1915,7 +2086,7 @@ fn fn_numer(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0].take() {
         i @ Value::Integer(_) => Ok(i),
         Value::Ratio(r) => Ok(r.numer().clone().into()),
-        ref v => Err(From::from(ExecError::expected("integer or ratio", v)))
+        ref v => Err(From::from(ExecError::expected("integer or ratio", v))),
     }
 }
 
@@ -1924,13 +2095,14 @@ fn fn_rat(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     if args.len() == 1 {
         match args[0].take() {
             Value::Float(f) => Ratio::from_f64(f)
-                .map(Value::Ratio).ok_or(From::from(ExecError::Overflow)),
-            Value::Integer(a) =>
-                Ok(Ratio::from_integer(a).into()),
+                .map(Value::Ratio)
+                .ok_or(From::from(ExecError::Overflow)),
+            Value::Integer(a) => Ok(Ratio::from_integer(a).into()),
             Value::Ratio(r) => Ok(r.into()),
-            ref v => Err(From::from(ExecError::expected("number", v)))
+            ref v => Err(From::from(ExecError::expected("number", v))),
         }
-    } else { // args.len() == 2
+    } else {
+        // args.len() == 2
         let a = args[0].take();
         let b = args[1].take();
 
@@ -1940,7 +2112,7 @@ fn fn_rat(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
                 Ok(Ratio::new(a, b).into())
             }
             (Value::Integer(_), ref b) => Err(From::from(ExecError::expected("integer", b))),
-            (ref a, _) => Err(From::from(ExecError::expected("integer", a)))
+            (ref a, _) => Err(From::from(ExecError::expected("integer", a))),
         }
     }
 }
@@ -1962,7 +2134,7 @@ fn recip_number(v: Value) -> Result<Value, Error> {
             test_zero(a.numer())?;
             Ok(a.recip().into())
         }
-        ref v => Err(From::from(ExecError::expected("number", v)))
+        ref v => Err(From::from(ExecError::expected("number", v))),
     }
 }
 
@@ -1982,7 +2154,7 @@ fn fn_string(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         }
         Value::Name(name) => Ok(ctx.scope().with_name(name, |s| s.into())),
         v @ Value::String(_) => Ok(v),
-        ref v => Err(From::from(ExecError::expected("char or string or name", v)))
+        ref v => Err(From::from(ExecError::expected("char or string or name", v))),
     }
 }
 
@@ -1991,7 +2163,7 @@ fn fn_path(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0].take() {
         Value::String(s) => Ok(PathBuf::from(s.into_string()).into()),
         v @ Value::Path(_) => Ok(v),
-        ref v => Err(From::from(ExecError::expected("string or path", v)))
+        ref v => Err(From::from(ExecError::expected("string or path", v))),
     }
 }
 
@@ -2000,10 +2172,11 @@ fn fn_bytes(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0].take() {
         Value::Unit => Ok(Bytes::from(Vec::new()).into()),
         li @ Value::List(_) => <Vec<u8>>::from_value_ref(&li)
-            .map(|b| Bytes::from(b).into()).map_err(From::from),
+            .map(|b| Bytes::from(b).into())
+            .map_err(From::from),
         Value::String(s) => Ok(Bytes::from(s.into_string()).into()),
         v @ Value::Bytes(_) => Ok(v),
-        ref v => Err(From::from(ExecError::expected("bytes or string", v)))
+        ref v => Err(From::from(ExecError::expected("bytes or string", v))),
     }
 }
 
@@ -2036,5 +2209,7 @@ fn fn_min(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 /// `panic` immediately interrupts execution upon evaluation.
 /// It accepts an optional parameter describing the reason for the panic.
 fn fn_panic(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
-    Err(From::from(ExecError::Panic(args.get_mut(0).map(|v| v.take()))))
+    Err(From::from(ExecError::Panic(
+        args.get_mut(0).map(|v| v.take()),
+    )))
 }

--- a/src/ketos/integer.rs
+++ b/src/ketos/integer.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 pub use num::bigint::Sign;
 
 use num::{self, BigInt, BigRational};
-use num::{FromPrimitive, ToPrimitive, Integer as NumInteger, Signed, Num, Zero, One};
+use num::{FromPrimitive, Integer as NumInteger, Num, One, Signed, ToPrimitive, Zero};
 
 /// Arbitrary precision signed integer
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
@@ -142,7 +142,8 @@ impl Integer {
     #[inline]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<Integer, FromStrRadixError> {
         BigInt::from_str_radix(s, radix)
-            .map(Integer).map_err(FromStrRadixError)
+            .map(Integer)
+            .map_err(FromStrRadixError)
     }
 
     /// Returns integer sign and a series of big-endian bytes.
@@ -324,15 +325,17 @@ impl Ratio {
     /// Returns the `Ratio` as an `f32` value.
     #[inline]
     pub fn to_f32(&self) -> Option<f32> {
-        self.numer().to_f32().and_then(
-            |n| self.denom().to_f32().map(|d| n / d))
+        self.numer()
+            .to_f32()
+            .and_then(|n| self.denom().to_f32().map(|d| n / d))
     }
 
     /// Returns the `Ratio` as an `f64` value.
     #[inline]
     pub fn to_f64(&self) -> Option<f64> {
-        self.numer().to_f64().and_then(
-            |n| self.denom().to_f64().map(|d| n / d))
+        self.numer()
+            .to_f64()
+            .and_then(|n| self.denom().to_f64().map(|d| n / d))
     }
 
     /// Truncates a `Ratio` and returns the whole portion as an `Integer`.
@@ -443,8 +446,12 @@ impl PartialEq<Integer> for Ratio {
 }
 
 impl PartialEq<Ratio> for Integer {
-    fn eq(&self, rhs: &Ratio) -> bool { rhs == self }
-    fn ne(&self, rhs: &Ratio) -> bool { rhs != self }
+    fn eq(&self, rhs: &Ratio) -> bool {
+        rhs == self
+    }
+    fn ne(&self, rhs: &Ratio) -> bool {
+        rhs != self
+    }
 }
 
 impl fmt::Display for Integer {
@@ -770,11 +777,15 @@ macro_rules! impl_ops {
 
         impl ::num::Zero for $ty {
             #[inline]
-            fn is_zero(&self) -> bool { self.0.is_zero() }
+            fn is_zero(&self) -> bool {
+                self.0.is_zero()
+            }
             #[inline]
-            fn zero() -> $ty { $ty(Zero::zero()) }
+            fn zero() -> $ty {
+                $ty(Zero::zero())
+            }
         }
-    }
+    };
 }
 
 impl_ops!{Integer}

--- a/src/ketos/io.rs
+++ b/src/ketos/io.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{self, Arguments};
 use std::fs;
-use std::io::{self, Stdout, Stderr, Write};
+use std::io::{self, Stderr, Stdout, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -17,9 +17,7 @@ pub struct GlobalIo {
 impl GlobalIo {
     /// Creates a `GlobalIo` instance using the given `stdout` writer.
     pub fn new(stdout: Rc<SharedWrite>) -> GlobalIo {
-        GlobalIo{
-            stdout: stdout,
-        }
+        GlobalIo { stdout: stdout }
     }
 
     /// Creates a `GlobalIo` instance whose `stdout` ignores all output.
@@ -49,7 +47,7 @@ pub struct IoError {
 impl IoError {
     /// Creates a new `IoError`.
     pub fn new(mode: IoMode, path: &Path, err: io::Error) -> IoError {
-        IoError{
+        IoError {
             mode: mode,
             path: path.to_owned(),
             err: err,
@@ -59,8 +57,13 @@ impl IoError {
 
 impl fmt::Display for IoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "failed to {} file `{}`: {}",
-            self.mode, self.path.display(), self.err)
+        write!(
+            f,
+            "failed to {} file `{}`: {}",
+            self.mode,
+            self.path.display(),
+            self.err
+        )
     }
 }
 
@@ -117,25 +120,22 @@ macro_rules! shared_write {
             fn write_all(&self, buf: &[u8]) -> Result<(), IoError> {
                 let mut lock = self.lock();
                 Write::write_all(&mut lock, buf)
-                    .map_err(|e| IoError::new(
-                        IoMode::Write, Path::new($name), e))
+                    .map_err(|e| IoError::new(IoMode::Write, Path::new($name), e))
             }
 
             fn write_fmt(&self, fmt: Arguments) -> Result<(), IoError> {
                 let mut lock = self.lock();
                 Write::write_fmt(&mut lock, fmt)
-                    .map_err(|e| IoError::new(
-                        IoMode::Write, Path::new($name), e))
+                    .map_err(|e| IoError::new(IoMode::Write, Path::new($name), e))
             }
 
             fn flush(&self) -> Result<(), IoError> {
                 let mut lock = self.lock();
                 Write::flush(&mut lock)
-                    .map_err(|e| IoError::new(
-                        IoMode::Write, Path::new($name), e))
+                    .map_err(|e| IoError::new(IoMode::Write, Path::new($name), e))
             }
         }
-    }
+    };
 }
 
 shared_write!{ Stdout => "<stdout>" }
@@ -145,9 +145,15 @@ shared_write!{ Stderr => "<stderr>" }
 pub struct Sink;
 
 impl SharedWrite for Sink {
-    fn write_all(&self, _buf: &[u8]) -> Result<(), IoError> { Ok(()) }
-    fn write_fmt(&self, _fmt: Arguments) -> Result<(), IoError> { Ok(()) }
-    fn flush(&self) -> Result<(), IoError> { Ok(()) }
+    fn write_all(&self, _buf: &[u8]) -> Result<(), IoError> {
+        Ok(())
+    }
+    fn write_fmt(&self, _fmt: Arguments) -> Result<(), IoError> {
+        Ok(())
+    }
+    fn flush(&self) -> Result<(), IoError> {
+        Ok(())
+    }
 }
 
 /// Wraps a `fs::File` as a shared writer, providing a path for error values.
@@ -159,7 +165,7 @@ pub struct File {
 impl File {
     /// Creates a new `File` from an open filehandle and path.
     pub fn new(file: fs::File, path: PathBuf) -> File {
-        File{
+        File {
             file: file,
             path: path,
         }
@@ -178,7 +184,6 @@ impl SharedWrite for File {
     }
 
     fn flush(&self) -> Result<(), IoError> {
-        Write::flush(&mut &self.file)
-            .map_err(|e| IoError::new(IoMode::Write, &self.path, e))
+        Write::flush(&mut &self.file).map_err(|e| IoError::new(IoMode::Write, &self.path, e))
     }
 }

--- a/src/ketos/lexer.rs
+++ b/src/ketos/lexer.rs
@@ -101,12 +101,12 @@ pub struct SpanDisplay<'a> {
 pub fn highlight_span(text: &str, span: Span) -> SpanDisplay {
     let line_start = match text[..span.lo as usize].rfind('\n') {
         Some(pos) => pos + 1,
-        None => 0
+        None => 0,
     };
 
     let line_end = match text[line_start..].find('\n') {
         Some(pos) => line_start + pos,
-        None => text.len()
+        None => text.len(),
     };
 
     let pre_chars = text[line_start..span.lo as usize].chars().count();
@@ -115,20 +115,21 @@ pub fn highlight_span(text: &str, span: Span) -> SpanDisplay {
     // If the span spans multiple lines, just highlight to the end of the line.
     let span_chars = match span_str.find('\n') {
         Some(pos) => span_str[..pos].chars().count(),
-        None => span_str.chars().count()
+        None => span_str.chars().count(),
     };
 
-    let line_no = text[..line_start].chars()
-        .filter(|&ch| ch == '\n').count() + 1;
+    let line_no = text[..line_start].chars().filter(|&ch| ch == '\n').count() + 1;
 
-    SpanDisplay{
+    SpanDisplay {
         filename: None,
         line: line_no,
         col: pre_chars,
         source: &text[line_start..line_end],
-        highlight: repeat(' ').take(pre_chars)
+        highlight: repeat(' ')
+            .take(pre_chars)
             .chain(once('^'))
-            .chain(repeat('~').take(span_chars.saturating_sub(1))).collect(),
+            .chain(repeat('~').take(span_chars.saturating_sub(1)))
+            .collect(),
     }
 }
 
@@ -148,7 +149,7 @@ struct File {
 impl CodeMap {
     /// Creates a new `CodeMap`.
     pub fn new() -> CodeMap {
-        CodeMap{
+        CodeMap {
             text: String::new(),
             files: Vec::new(),
         }
@@ -159,7 +160,7 @@ impl CodeMap {
         let begin = self.text.len() as BytePos;
 
         self.text.push_str(text);
-        self.files.push(File{
+        self.files.push(File {
             path: path,
             begin: begin,
         });
@@ -181,12 +182,12 @@ impl CodeMap {
     pub fn highlight_span(&self, span: Span) -> SpanDisplay {
         let n = match self.files.binary_search_by(|f| f.begin.cmp(&span.lo)) {
             Ok(n) => n,
-            Err(n) => n - 1
+            Err(n) => n - 1,
         };
 
         let end = match self.files.get(n as usize + 1) {
             Some(f) => f.begin,
-            None => self.text.len() as BytePos
+            None => self.text.len() as BytePos,
         };
 
         if span.hi > end {
@@ -195,10 +196,13 @@ impl CodeMap {
 
         let f = &self.files[n as usize];
 
-        let Span{lo, hi} = span;
-        let adj_span = Span{lo: lo - f.begin, hi: hi - f.begin};
+        let Span { lo, hi } = span;
+        let adj_span = Span {
+            lo: lo - f.begin,
+            hi: hi - f.begin,
+        };
 
-        SpanDisplay{
+        SpanDisplay {
             filename: f.path.as_ref().map(|s| &s[..]),
             ..highlight_span(&self.text[f.begin as usize..end as usize], adj_span)
         }
@@ -224,24 +228,30 @@ pub struct Span {
 impl Span {
     /// Returns an empty `Span` at the given offset.
     pub fn empty(pos: BytePos) -> Span {
-        Span{lo: pos, hi: pos}
+        Span { lo: pos, hi: pos }
     }
 
     /// Returns a `Span` spanning a single char.
     pub fn one(pos: BytePos, ch: char) -> Span {
-        Span{lo: pos, hi: pos + ch.len_utf8() as BytePos}
+        Span {
+            lo: pos,
+            hi: pos + ch.len_utf8() as BytePos,
+        }
     }
 
     /// Returns a `Span` spanning a single byte.
     pub fn byte(pos: BytePos) -> Span {
-        Span{lo: pos, hi: pos + 1}
+        Span {
+            lo: pos,
+            hi: pos + 1,
+        }
     }
 }
 
 impl<'lex> Lexer<'lex> {
     /// Creates a new `Lexer` to read tokens from the input string.
     pub fn new(input: &str, offset: BytePos) -> Lexer {
-        Lexer{
+        Lexer {
             input: input,
             cur_pos: 0,
             code_offset: offset,
@@ -265,82 +275,82 @@ impl<'lex> Lexer<'lex> {
                     Some((_, '@')) => Ok((Token::CommaAt, 2)),
                     _ => Ok((Token::Comma, 1)),
                 },
-                '-' | '0' ... '9' => parse_number(&self.input[ind..]),
+                '-' | '0'...'9' => parse_number(&self.input[ind..]),
                 '"' => Ok(parse_string(&self.input[ind..], self.code_offset + lo)?),
                 '#' => match chars.next() {
-                    Some((_, 'b')) => {
-                        match chars.next() {
-                            Some((_, 'r')) => Ok(parse_raw_bytes(&self.input[ind..],
-                                self.code_offset + lo)?),
-                            Some((_, '"')) => Ok(parse_bytes(&self.input[ind..],
-                                self.code_offset + lo)?),
-                            Some((_, '\'')) => Ok(parse_byte(&self.input[ind..],
-                                self.code_offset + lo)?),
-                            _ => Err(ParseErrorKind::InvalidToken)
+                    Some((_, 'b')) => match chars.next() {
+                        Some((_, 'r')) => {
+                            Ok(parse_raw_bytes(&self.input[ind..], self.code_offset + lo)?)
                         }
-                    }
-                    Some((_, 'p')) => {
-                        match chars.next() {
-                            Some((_, 'r')) => Ok(parse_raw_path(&self.input[ind..],
-                                self.code_offset + lo)?),
-                            Some((_, '"')) => Ok(parse_path(&self.input[ind..],
-                                self.code_offset + lo)?),
-                            _ => Err(ParseErrorKind::InvalidToken)
+                        Some((_, '"')) => {
+                            Ok(parse_bytes(&self.input[ind..], self.code_offset + lo)?)
                         }
-                    }
-                    Some((_, '\'')) => Ok(parse_char(&self.input[ind..],
-                        self.code_offset + lo)?),
+                        Some((_, '\'')) => {
+                            Ok(parse_byte(&self.input[ind..], self.code_offset + lo)?)
+                        }
+                        _ => Err(ParseErrorKind::InvalidToken),
+                    },
+                    Some((_, 'p')) => match chars.next() {
+                        Some((_, 'r')) => {
+                            Ok(parse_raw_path(&self.input[ind..], self.code_offset + lo)?)
+                        }
+                        Some((_, '"')) => {
+                            Ok(parse_path(&self.input[ind..], self.code_offset + lo)?)
+                        }
+                        _ => Err(ParseErrorKind::InvalidToken),
+                    },
+                    Some((_, '\'')) => Ok(parse_char(&self.input[ind..], self.code_offset + lo)?),
                     Some((_, '|')) => match consume_block_comment(ind, &mut chars) {
                         Ok(n) => {
                             self.cur_pos += n as BytePos;
                             continue;
                         }
-                        Err(k) => Err(k)
+                        Err(k) => Err(k),
                     },
                     Some(_) => Err(ParseErrorKind::InvalidToken),
-                    None => Err(ParseErrorKind::UnexpectedEof)
+                    None => Err(ParseErrorKind::UnexpectedEof),
                 },
                 'r' => match chars.next() {
-                    Some((_, '"')) | Some((_, '#')) =>
-                        Ok(parse_raw_string(&self.input[ind..],
-                            self.code_offset + lo)?),
-                    _ => parse_name(&self.input[ind..])
+                    Some((_, '"')) | Some((_, '#')) => {
+                        Ok(parse_raw_string(&self.input[ind..], self.code_offset + lo)?)
+                    }
+                    _ => parse_name(&self.input[ind..]),
                 },
                 ':' => parse_keyword(&self.input[ind..]),
-                ';' => {
-                    match chars.clone().next() {
-                        Some((_, ';')) => Ok(parse_doc_comment(&self.input[ind..])),
-                        _ => {
-                            self.cur_pos += consume_line_comment(ind, &mut chars) as BytePos;
-                            continue;
-                        }
+                ';' => match chars.clone().next() {
+                    Some((_, ';')) => Ok(parse_doc_comment(&self.input[ind..])),
+                    _ => {
+                        self.cur_pos += consume_line_comment(ind, &mut chars) as BytePos;
+                        continue;
                     }
-                }
+                },
                 '\r' => match chars.next() {
                     Some((_, '\n')) => {
                         self.cur_pos += 2;
                         continue;
                     }
-                    _ => Err(ParseErrorKind::InvalidChar('\r'))
+                    _ => Err(ParseErrorKind::InvalidChar('\r')),
                 },
                 ch if ch.is_whitespace() => {
                     self.cur_pos += ch.len_utf8() as BytePos;
                     continue;
                 }
                 _ if is_identifier(ch) => parse_name(&self.input[ind..]),
-                ch => Err(ParseErrorKind::InvalidChar(ch))
+                ch => Err(ParseErrorKind::InvalidChar(ch)),
             };
 
             let (tok, size) = match res {
                 Ok(v) => v,
-                Err(kind) => return Err(ParseError::new(
-                    self.span(Span::one(lo, ch)), kind))
+                Err(kind) => return Err(ParseError::new(self.span(Span::one(lo, ch)), kind)),
             };
 
             self.cur_pos += size as BytePos;
             self.input = &self.input[ind + size..];
 
-            let sp = Span{lo: lo, hi: lo + size as BytePos};
+            let sp = Span {
+                lo: lo,
+                hi: lo + size as BytePos,
+            };
 
             return Ok((self.span(sp), tok));
         }
@@ -364,7 +374,7 @@ impl<'lex> Lexer<'lex> {
         if self.input.starts_with("#!") {
             let pos = match self.input.find('\n') {
                 Some(pos) => pos,
-                None => self.input.len()
+                None => self.input.len(),
             };
             self.input = &self.input[pos..];
             self.cur_pos = pos as BytePos;
@@ -379,8 +389,11 @@ impl<'lex> Lexer<'lex> {
     }
 
     fn span(&self, span: Span) -> Span {
-        let Span{lo, hi} = span;
-        Span{lo: self.code_offset + lo, hi: self.code_offset + hi}
+        let Span { lo, hi } = span;
+        Span {
+            lo: self.code_offset + lo,
+            hi: self.code_offset + hi,
+        }
     }
 }
 
@@ -398,7 +411,7 @@ fn consume_block_comment(start: usize, chars: &mut CharIndices) -> Result<usize,
                     }
                 }
                 Some(_) => (),
-                None => break
+                None => break,
             },
             Some((_, '#')) => match chars.clone().next() {
                 Some((_, '|')) => {
@@ -406,13 +419,13 @@ fn consume_block_comment(start: usize, chars: &mut CharIndices) -> Result<usize,
                     n_blocks += 1;
                 }
                 Some(_) => (),
-                None => break
+                None => break,
             },
             Some((ind, ';')) => {
                 consume_line_comment(ind, chars);
             }
             Some(_) => (),
-            None => break
+            None => break,
         }
     }
 
@@ -439,17 +452,13 @@ fn parse_doc_comment(input: &str) -> (Token, usize) {
 
     loop {
         match chars.next() {
-            Some((_, ';')) if begin_line => {
-                match chars.next() {
-                    Some((_, ';')) => {
-                        begin_line = false;
-                    }
-                    _ => break
+            Some((_, ';')) if begin_line => match chars.next() {
+                Some((_, ';')) => {
+                    begin_line = false;
                 }
-            }
-            Some((_, ch)) if begin_line &&
-                ch != '\r' && ch != '\n' &&
-                ch.is_whitespace() => (),
+                _ => break,
+            },
+            Some((_, ch)) if begin_line && ch != '\r' && ch != '\n' && ch.is_whitespace() => (),
             _ if begin_line => break,
             Some((_, '\r')) => {
                 if let Some((ind, '\n')) = chars.next() {
@@ -474,10 +483,10 @@ fn parse_doc_comment(input: &str) -> (Token, usize) {
 
 fn is_identifier(ch: char) -> bool {
     match ch {
-        '!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' |
-        '<' | '=' | '>' | '?' | '^' | '_' | '|' => true,
+        '!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' | '<' | '=' | '>' | '?' | '^' | '_'
+        | '|' => true,
         _ if ch.is_alphanumeric() => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -525,7 +534,7 @@ fn parse_number(input: &str) -> Result<(Token, usize), ParseErrorKind> {
         match input[1..].chars().next() {
             Some(ch) if ch.is_digit(10) => (10, 1, &input[1..]),
             // Actually a name beginning with '-' rather a number
-            _ => return parse_name(input)
+            _ => return parse_name(input),
         }
     } else {
         (10, 0, input)
@@ -572,7 +581,7 @@ fn parse_number(input: &str) -> Result<(Token, usize), ParseErrorKind> {
                 size = prefix_offset + ind;
                 break;
             }
-            _ => return Err(ParseErrorKind::InvalidLiteral)
+            _ => return Err(ParseErrorKind::InvalidLiteral),
         }
     }
 
@@ -637,7 +646,7 @@ mod test {
     use parser::ParseErrorKind;
 
     fn sp(lo: BytePos, hi: BytePos) -> Span {
-        Span{lo: lo, hi: hi}
+        Span { lo: lo, hi: hi }
     }
 
     fn tokens(s: &str) -> Vec<(Span, Token)> {
@@ -661,194 +670,317 @@ mod test {
 
     #[test]
     fn test_comment() {
-        assert_eq!(tokens("1\n;foo\n2"),
-            [(sp(0, 1), Token::Integer("1", 10)),
-             (sp(7, 8), Token::Integer("2", 10))]);
+        assert_eq!(
+            tokens("1\n;foo\n2"),
+            [
+                (sp(0, 1), Token::Integer("1", 10)),
+                (sp(7, 8), Token::Integer("2", 10))
+            ]
+        );
 
-        assert_eq!(tokens("1 #| lol |# 2"),
-            [(sp(0, 1), Token::Integer("1", 10)),
-             (sp(12, 13), Token::Integer("2", 10))]);
+        assert_eq!(
+            tokens("1 #| lol |# 2"),
+            [
+                (sp(0, 1), Token::Integer("1", 10)),
+                (sp(12, 13), Token::Integer("2", 10))
+            ]
+        );
 
-        assert_eq!(tokens("1 #| lol\n; wut |#\n nou |# 2"),
-            [(sp(0, 1), Token::Integer("1", 10)),
-             (sp(26, 27), Token::Integer("2", 10))]);
+        assert_eq!(
+            tokens("1 #| lol\n; wut |#\n nou |# 2"),
+            [
+                (sp(0, 1), Token::Integer("1", 10)),
+                (sp(26, 27), Token::Integer("2", 10))
+            ]
+        );
 
-        assert_eq!(tokens("1 #| lol #| wut |# #| nou |# lolk |# 2"),
-            [(sp(0, 1), Token::Integer("1", 10)),
-             (sp(37, 38), Token::Integer("2", 10))]);
+        assert_eq!(
+            tokens("1 #| lol #| wut |# #| nou |# lolk |# 2"),
+            [
+                (sp(0, 1), Token::Integer("1", 10)),
+                (sp(37, 38), Token::Integer("2", 10))
+            ]
+        );
     }
 
     #[test]
     fn test_lexer() {
-        assert_eq!(tokens("1 2 3"),
-            [(sp(0, 1), Token::Integer("1", 10)),
-             (sp(2, 3), Token::Integer("2", 10)),
-             (sp(4, 5), Token::Integer("3", 10))]);
+        assert_eq!(
+            tokens("1 2 3"),
+            [
+                (sp(0, 1), Token::Integer("1", 10)),
+                (sp(2, 3), Token::Integer("2", 10)),
+                (sp(4, 5), Token::Integer("3", 10))
+            ]
+        );
 
-        assert_eq!(tokens("1 foo 3"),
-            [(sp(0, 1), Token::Integer("1", 10)),
-             (sp(2, 5), Token::Name("foo")),
-             (sp(6, 7), Token::Integer("3", 10))]);
+        assert_eq!(
+            tokens("1 foo 3"),
+            [
+                (sp(0, 1), Token::Integer("1", 10)),
+                (sp(2, 5), Token::Name("foo")),
+                (sp(6, 7), Token::Integer("3", 10))
+            ]
+        );
 
-        assert_eq!(tokens("0b0101 0o777 0xdeadBEEF"),
-            [(sp(0, 6), Token::Integer("0b0101", 2)),
-             (sp(7, 12), Token::Integer("0o777", 8)),
-             (sp(13, 23), Token::Integer("0xdeadBEEF", 16))]);
+        assert_eq!(
+            tokens("0b0101 0o777 0xdeadBEEF"),
+            [
+                (sp(0, 6), Token::Integer("0b0101", 2)),
+                (sp(7, 12), Token::Integer("0o777", 8)),
+                (sp(13, 23), Token::Integer("0xdeadBEEF", 16))
+            ]
+        );
 
-        assert_eq!(tokens("1/2 -10/3"),
-            [(sp(0, 3), Token::Ratio("1/2")),
-             (sp(4, 9), Token::Ratio("-10/3"))]);
+        assert_eq!(
+            tokens("1/2 -10/3"),
+            [
+                (sp(0, 3), Token::Ratio("1/2")),
+                (sp(4, 9), Token::Ratio("-10/3"))
+            ]
+        );
 
-        assert_eq!(tokens("-1 2.0 3e100 -4.1e-2 5e+1"),
-            [(sp(0, 2), Token::Integer("-1", 10)),
-             (sp(3, 6), Token::Float("2.0")),
-             (sp(7, 12), Token::Float("3e100")),
-             (sp(13, 20), Token::Float("-4.1e-2")),
-             (sp(21, 25), Token::Float("5e+1"))]);
+        assert_eq!(
+            tokens("-1 2.0 3e100 -4.1e-2 5e+1"),
+            [
+                (sp(0, 2), Token::Integer("-1", 10)),
+                (sp(3, 6), Token::Float("2.0")),
+                (sp(7, 12), Token::Float("3e100")),
+                (sp(13, 20), Token::Float("-4.1e-2")),
+                (sp(21, 25), Token::Float("5e+1"))
+            ]
+        );
 
-        assert_eq!(tokens(r"#'a' #'\'' #'\x7f' #'\u{1234}'"),
-            [(sp(0, 4), Token::Char("#'a'")),
-             (sp(5, 10), Token::Char(r"#'\''")),
-             (sp(11, 18), Token::Char(r"#'\x7f'")),
-             (sp(19, 30), Token::Char(r"#'\u{1234}'"))]);
+        assert_eq!(
+            tokens(r"#'a' #'\'' #'\x7f' #'\u{1234}'"),
+            [
+                (sp(0, 4), Token::Char("#'a'")),
+                (sp(5, 10), Token::Char(r"#'\''")),
+                (sp(11, 18), Token::Char(r"#'\x7f'")),
+                (sp(19, 30), Token::Char(r"#'\u{1234}'"))
+            ]
+        );
 
-        assert_eq!(tokens(r"#b'a' #b'\'' #b'\xff'"),
-            [(sp(0, 5), Token::Byte("#b'a'")),
-             (sp(6, 12), Token::Byte(r"#b'\''")),
-             (sp(13, 21), Token::Byte(r"#b'\xff'"))]);
+        assert_eq!(
+            tokens(r"#b'a' #b'\'' #b'\xff'"),
+            [
+                (sp(0, 5), Token::Byte("#b'a'")),
+                (sp(6, 12), Token::Byte(r"#b'\''")),
+                (sp(13, 21), Token::Byte(r"#b'\xff'"))
+            ]
+        );
 
-        assert_eq!(tokens(r#"#b"foo" #b"bar\xff""#),
-            [(sp(0, 7), Token::Bytes(r#"#b"foo""#)),
-             (sp(8, 19), Token::Bytes(r#"#b"bar\xff""#))]);
+        assert_eq!(
+            tokens(r#"#b"foo" #b"bar\xff""#),
+            [
+                (sp(0, 7), Token::Bytes(r#"#b"foo""#)),
+                (sp(8, 19), Token::Bytes(r#"#b"bar\xff""#))
+            ]
+        );
 
-        assert_eq!(tokens(r#"#p"foo" #p"bar""#),
-            [(sp(0, 7), Token::Path(r#"#p"foo""#)),
-             (sp(8, 15), Token::Path(r#"#p"bar""#))]);
+        assert_eq!(
+            tokens(r#"#p"foo" #p"bar""#),
+            [
+                (sp(0, 7), Token::Path(r#"#p"foo""#)),
+                (sp(8, 15), Token::Path(r#"#p"bar""#))
+            ]
+        );
 
-        assert_eq!(tokens(r##"#pr"foo\" #pr#"bar"#"##),
-            [(sp(0, 9), Token::Path(r#"#pr"foo\""#)),
-             (sp(10, 20), Token::Path(r##"#pr#"bar"#"##))]);
+        assert_eq!(
+            tokens(r##"#pr"foo\" #pr#"bar"#"##),
+            [
+                (sp(0, 9), Token::Path(r#"#pr"foo\""#)),
+                (sp(10, 20), Token::Path(r##"#pr#"bar"#"##))
+            ]
+        );
 
-        assert_eq!(tokens(r###""a" r"\" r#"b"# r##"c"## "\x7f" "\u{1234}""###),
-            [(sp(0, 3), Token::String(r#""a""#)),
-             (sp(4, 8), Token::String(r#"r"\""#)),
-             (sp(9, 15), Token::String(r##"r#"b"#"##)),
-             (sp(16, 24), Token::String(r###"r##"c"##"###)),
-             (sp(25, 31), Token::String(r#""\x7f""#)),
-             (sp(32, 42), Token::String(r#""\u{1234}""#))]);
+        assert_eq!(
+            tokens(r###""a" r"\" r#"b"# r##"c"## "\x7f" "\u{1234}""###),
+            [
+                (sp(0, 3), Token::String(r#""a""#)),
+                (sp(4, 8), Token::String(r#"r"\""#)),
+                (sp(9, 15), Token::String(r##"r#"b"#"##)),
+                (sp(16, 24), Token::String(r###"r##"c"##"###)),
+                (sp(25, 31), Token::String(r#""\x7f""#)),
+                (sp(32, 42), Token::String(r#""\u{1234}""#))
+            ]
+        );
 
         assert_eq!(tokens("foo"), [(sp(0, 3), Token::Name("foo"))]);
 
-        assert_eq!(tokens("()"), [
-            (sp(0, 1), Token::LeftParen), (sp(1, 2), Token::RightParen)]);
+        assert_eq!(
+            tokens("()"),
+            [(sp(0, 1), Token::LeftParen), (sp(1, 2), Token::RightParen)]
+        );
 
-        assert_eq!(tokens("(foo)"),
-            [(sp(0, 1), Token::LeftParen),
-             (sp(1, 4), Token::Name("foo")),
-             (sp(4, 5), Token::RightParen)]);
+        assert_eq!(
+            tokens("(foo)"),
+            [
+                (sp(0, 1), Token::LeftParen),
+                (sp(1, 4), Token::Name("foo")),
+                (sp(4, 5), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(foo bar baz)"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(foo bar baz)"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 4), Token::Name("foo")),
                 (sp(5, 8), Token::Name("bar")),
                 (sp(9, 12), Token::Name("baz")),
-            (sp(12, 13), Token::RightParen)]);
+                (sp(12, 13), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(foo\nbar\nbaz)"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(foo\nbar\nbaz)"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 4), Token::Name("foo")),
                 (sp(5, 8), Token::Name("bar")),
                 (sp(9, 12), Token::Name("baz")),
-            (sp(12, 13), Token::RightParen)]);
+                (sp(12, 13), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(foo\r\nbar\r\nbaz)"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(foo\r\nbar\r\nbaz)"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 4), Token::Name("foo")),
                 (sp(6, 9), Token::Name("bar")),
                 (sp(11, 14), Token::Name("baz")),
-            (sp(14, 15), Token::RightParen)]);
+                (sp(14, 15), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(- 1)"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(- 1)"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 2), Token::Name("-")),
                 (sp(3, 4), Token::Integer("1", 10)),
-            (sp(4, 5), Token::RightParen)]);
+                (sp(4, 5), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(foo (bar baz) (spam eggs))"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(foo (bar baz) (spam eggs))"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 4), Token::Name("foo")),
                 (sp(5, 6), Token::LeftParen),
-                    (sp(6, 9), Token::Name("bar")),
-                    (sp(10, 13), Token::Name("baz")),
+                (sp(6, 9), Token::Name("bar")),
+                (sp(10, 13), Token::Name("baz")),
                 (sp(13, 14), Token::RightParen),
                 (sp(15, 16), Token::LeftParen),
-                    (sp(16, 20), Token::Name("spam")),
-                    (sp(21, 25), Token::Name("eggs")),
+                (sp(16, 20), Token::Name("spam")),
+                (sp(21, 25), Token::Name("eggs")),
                 (sp(25, 26), Token::RightParen),
-            (sp(26, 27), Token::RightParen)]);
+                (sp(26, 27), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(foo '(bar baz))"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(foo '(bar baz))"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 4), Token::Name("foo")),
                 (sp(5, 6), Token::Quote),
                 (sp(6, 7), Token::LeftParen),
-                    (sp(7, 10), Token::Name("bar")),
-                    (sp(11, 14), Token::Name("baz")),
+                (sp(7, 10), Token::Name("bar")),
+                (sp(11, 14), Token::Name("baz")),
                 (sp(14, 15), Token::RightParen),
-            (sp(15, 16), Token::RightParen)]);
+                (sp(15, 16), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(+ 1 2)"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(+ 1 2)"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 2), Token::Name("+")),
                 (sp(3, 4), Token::Integer("1", 10)),
                 (sp(5, 6), Token::Integer("2", 10)),
-            (sp(6, 7), Token::RightParen)]);
+                (sp(6, 7), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("(* 1 2 (+ 3 4))"),
-            [(sp(0, 1), Token::LeftParen),
+        assert_eq!(
+            tokens("(* 1 2 (+ 3 4))"),
+            [
+                (sp(0, 1), Token::LeftParen),
                 (sp(1, 2), Token::Name("*")),
                 (sp(3, 4), Token::Integer("1", 10)),
                 (sp(5, 6), Token::Integer("2", 10)),
                 (sp(7, 8), Token::LeftParen),
-                    (sp(8, 9), Token::Name("+")),
-                    (sp(10, 11), Token::Integer("3", 10)),
-                    (sp(12, 13), Token::Integer("4", 10)),
+                (sp(8, 9), Token::Name("+")),
+                (sp(10, 11), Token::Integer("3", 10)),
+                (sp(12, 13), Token::Integer("4", 10)),
                 (sp(13, 14), Token::RightParen),
-            (sp(14, 15), Token::RightParen)]);
+                (sp(14, 15), Token::RightParen)
+            ]
+        );
 
-        assert_eq!(tokens("foo ; bar\nbaz"),
-            [(sp(0, 3), Token::Name("foo")),
-             (sp(10, 13), Token::Name("baz"))]);
+        assert_eq!(
+            tokens("foo ; bar\nbaz"),
+            [
+                (sp(0, 3), Token::Name("foo")),
+                (sp(10, 13), Token::Name("baz"))
+            ]
+        );
 
-        assert_eq!(tokens("foo; bar\nbaz"),
-            [(sp(0, 3), Token::Name("foo")),
-             (sp(9, 12), Token::Name("baz"))]);
+        assert_eq!(
+            tokens("foo; bar\nbaz"),
+            [
+                (sp(0, 3), Token::Name("foo")),
+                (sp(9, 12), Token::Name("baz"))
+            ]
+        );
 
-        assert_eq!(tokens(";; foo"),
-            [(sp(0, 6), Token::DocComment(";; foo"))]);
+        assert_eq!(tokens(";; foo"), [(sp(0, 6), Token::DocComment(";; foo"))]);
 
-        assert_eq!(tokens(";; foo\n"),
-            [(sp(0, 7), Token::DocComment(";; foo\n"))]);
+        assert_eq!(
+            tokens(";; foo\n"),
+            [(sp(0, 7), Token::DocComment(";; foo\n"))]
+        );
 
-        assert_eq!(tokens(";; foo\nbar"),
-            [(sp(0, 7), Token::DocComment(";; foo\n")),
-             (sp(7, 10), Token::Name("bar"))]);
+        assert_eq!(
+            tokens(";; foo\nbar"),
+            [
+                (sp(0, 7), Token::DocComment(";; foo\n")),
+                (sp(7, 10), Token::Name("bar"))
+            ]
+        );
 
-        assert_eq!(tokens(";; foo\n; bar\n"),
-            [(sp(0, 7), Token::DocComment(";; foo\n"))]);
+        assert_eq!(
+            tokens(";; foo\n; bar\n"),
+            [(sp(0, 7), Token::DocComment(";; foo\n"))]
+        );
 
-        assert_eq!(tokens("; foo\n;; bar\n"),
-            [(sp(6, 13), Token::DocComment(";; bar\n"))]);
+        assert_eq!(
+            tokens("; foo\n;; bar\n"),
+            [(sp(6, 13), Token::DocComment(";; bar\n"))]
+        );
 
-        assert_eq!(tokens(";; foo\n;;\n;; bar\n"),
-            [(sp(0, 17), Token::DocComment(";; foo\n;;\n;; bar\n"))]);
+        assert_eq!(
+            tokens(";; foo\n;;\n;; bar\n"),
+            [(sp(0, 17), Token::DocComment(";; foo\n;;\n;; bar\n"))]
+        );
 
-        assert_eq!(tokens(";; foo\n;; bar\n"),
-            [(sp(0, 14), Token::DocComment(";; foo\n;; bar\n"))]);
+        assert_eq!(
+            tokens(";; foo\n;; bar\n"),
+            [(sp(0, 14), Token::DocComment(";; foo\n;; bar\n"))]
+        );
 
-        assert_eq!(tokens(";; foo\n\n;; bar\n"),
-            [(sp(0, 7), Token::DocComment(";; foo\n")),
-             (sp(8, 15), Token::DocComment(";; bar\n"))]);
+        assert_eq!(
+            tokens(";; foo\n\n;; bar\n"),
+            [
+                (sp(0, 7), Token::DocComment(";; foo\n")),
+                (sp(8, 15), Token::DocComment(";; bar\n"))
+            ]
+        );
     }
 
     #[test]

--- a/src/ketos/lib.rs
+++ b/src/ketos/lib.rs
@@ -29,21 +29,23 @@
 extern crate byteorder;
 extern crate num;
 extern crate rand;
-#[cfg(feature = "serde")] extern crate serde;
+#[cfg(feature = "serde")]
+extern crate serde;
 
 #[cfg(test)]
-#[macro_use] extern crate assert_matches;
+#[macro_use]
+extern crate assert_matches;
 
 pub use bytecode::Code;
 pub use bytes::Bytes;
-pub use completion::complete_name;
 pub use compile::CompileError;
+pub use completion::complete_name;
 pub use encode::{DecodeError, EncodeError};
 pub use error::Error;
-pub use exec::{Context, ExecError, panic, panic_none};
+pub use exec::{panic, panic_none, Context, ExecError};
 pub use function::Arity;
-pub use interpreter::{Builder, Interpreter};
 pub use integer::{Integer, Ratio};
+pub use interpreter::{Builder, Interpreter};
 pub use io::{File, GlobalIo, IoError, SharedWrite};
 pub use module::{BuiltinModuleLoader, FileModuleLoader, Module, ModuleBuilder, ModuleLoader};
 pub use name::{Name, NameStore};
@@ -54,15 +56,18 @@ pub use scope::{GlobalScope, Scope};
 pub use structs::{StructDef, StructValue};
 pub use trace::{clear_traceback, get_traceback, set_traceback, take_traceback, Trace};
 pub use value::{ForeignValue, FromValue, FromValueRef, Value};
-#[cfg(feature = "serde")] pub use value_decode::decode_value;
-#[cfg(feature = "serde")] pub use value_encode::encode_value;
+#[cfg(feature = "serde")]
+pub use value_decode::decode_value;
+#[cfg(feature = "serde")]
+pub use value_encode::encode_value;
 
-#[macro_use] pub mod any;
+#[macro_use]
+pub mod any;
 pub mod args;
 pub mod bytecode;
 pub mod bytes;
-pub mod completion;
 pub mod compile;
+pub mod completion;
 mod const_fold;
 pub mod encode;
 pub mod error;
@@ -76,8 +81,8 @@ pub mod module;
 pub mod name;
 pub mod parser;
 pub mod pretty;
-pub mod restrict;
 pub mod rc_vec;
+pub mod restrict;
 pub mod run;
 pub mod scope;
 mod string;
@@ -85,8 +90,10 @@ pub mod string_fmt;
 pub mod structs;
 pub mod trace;
 pub mod value;
-#[cfg(feature = "serde")] pub mod value_decode;
-#[cfg(feature = "serde")] pub mod value_encode;
+#[cfg(feature = "serde")]
+pub mod value_decode;
+#[cfg(feature = "serde")]
+pub mod value_encode;
 
 mod mod_code;
 mod mod_math;

--- a/src/ketos/mod_math.rs
+++ b/src/ketos/mod_math.rs
@@ -12,27 +12,61 @@ use value::Value;
 /// Loads the `math` module into the given scope.
 pub fn load(scope: Scope) -> Module {
     ModuleBuilder::new("math", scope)
-        .add_constant("e",          consts::E)
-        .add_doc     ("e",  "Euler's number")
-        .add_constant("pi",         consts::PI)
-        .add_doc     ("pi", "The ratio of a circle's circumference to its diameter")
-        .add_function("acos",       fn_acos,    Exact(1), Some("\
+        .add_constant("e", consts::E)
+        .add_doc("e", "Euler's number")
+        .add_constant("pi", consts::PI)
+        .add_doc(
+            "pi",
+            "The ratio of a circle's circumference to its diameter",
+        ).add_function(
+            "acos",
+            fn_acos,
+            Exact(1),
+            Some(
+                "\
 Computes the arctangent of a number.
-Return value is in radians in the range `[-pi/2, pi/2]`."))
-        .add_function("acosh",      fn_acosh,   Exact(1),
-            Some("Inverse hyperbolic cosine function."))
-        .add_function("asin",       fn_asin,    Exact(1), Some("\
+Return value is in radians in the range `[-pi/2, pi/2]`.",
+            ),
+        ).add_function(
+            "acosh",
+            fn_acosh,
+            Exact(1),
+            Some("Inverse hyperbolic cosine function."),
+        ).add_function(
+            "asin",
+            fn_asin,
+            Exact(1),
+            Some(
+                "\
 Computes the arcsine of a number.
 Return value is in radians in the range `[-pi/2, pi/2]` or `NaN`
-if the number is outside the range `[-1, 1]`."))
-        .add_function("asinh",      fn_asinh,   Exact(1),
-            Some("Inverse hyperbolic sine function"))
-        .add_function("atan",       fn_atan,    Exact(1), Some("\
+if the number is outside the range `[-1, 1]`.",
+            ),
+        ).add_function(
+            "asinh",
+            fn_asinh,
+            Exact(1),
+            Some("Inverse hyperbolic sine function"),
+        ).add_function(
+            "atan",
+            fn_atan,
+            Exact(1),
+            Some(
+                "\
 Computes the arctangent of a number.
-Return value is in radians in the range `[-pi/2, pi/2]`."))
-        .add_function("atanh",      fn_atanh,   Exact(1),
-            Some("Inverse hyperbolic tangent function."))
-        .add_function("atan2",      fn_atan2,   Exact(2), Some("\
+Return value is in radians in the range `[-pi/2, pi/2]`.",
+            ),
+        ).add_function(
+            "atanh",
+            fn_atanh,
+            Exact(1),
+            Some("Inverse hyperbolic tangent function."),
+        ).add_function(
+            "atan2",
+            fn_atan2,
+            Exact(2),
+            Some(
+                "\
     (atan2 y x)
 
 Computes the four quadrant arctangent of `y` and `x`.
@@ -40,37 +74,85 @@ Computes the four quadrant arctangent of `y` and `x`.
 * `x = 0`, `y = 0`: `0`
 * `x >= 0`: `arctan(y/x)` -> `[-pi/2, pi/2]`
 * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
-* `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`"))
-        .add_function("cos",        fn_cos,     Exact(1),
-            Some("Computes the cosine of a number, in radians."))
-        .add_function("cosh",       fn_cosh,    Exact(1),
-            Some("Hyperbolic cosine function."))
-        .add_function("degrees",    fn_degrees, Exact(1),
-            Some("Converts a value in radians to degrees."))
-        .add_function("ln",         fn_ln,      Exact(1),
-            Some("Returns the natural logarithm of a number."))
-        .add_function("log",        fn_log,     Exact(2), Some("\
+* `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`",
+            ),
+        ).add_function(
+            "cos",
+            fn_cos,
+            Exact(1),
+            Some("Computes the cosine of a number, in radians."),
+        ).add_function(
+            "cosh",
+            fn_cosh,
+            Exact(1),
+            Some("Hyperbolic cosine function."),
+        ).add_function(
+            "degrees",
+            fn_degrees,
+            Exact(1),
+            Some("Converts a value in radians to degrees."),
+        ).add_function(
+            "ln",
+            fn_ln,
+            Exact(1),
+            Some("Returns the natural logarithm of a number."),
+        ).add_function(
+            "log",
+            fn_log,
+            Exact(2),
+            Some(
+                "\
     (log n base)
 
-Returns the logarithm of a number with respect to an arbitrary base."))
-        .add_function("log2",       fn_log2,    Exact(1), Some("\
-Returns the base 2 logarithm of a number."))
-        .add_function("log10",      fn_log10,   Exact(1), Some("\
-Returns the base 10 logarithm of a number."))
-        .add_function("radians",    fn_radians, Exact(1),
-            Some("Converts a value in degrees to radians."))
-        .add_function("sin",        fn_sin,     Exact(1),
-            Some("Computes the sine of a number, in radians."))
-        .add_function("sinh",       fn_sinh,    Exact(1),
-            Some("Hyperbolic sine function."))
-        .add_function("sqrt",       fn_sqrt,    Exact(1), Some("\
+Returns the logarithm of a number with respect to an arbitrary base.",
+            ),
+        ).add_function(
+            "log2",
+            fn_log2,
+            Exact(1),
+            Some(
+                "\
+                 Returns the base 2 logarithm of a number.",
+            ),
+        ).add_function(
+            "log10",
+            fn_log10,
+            Exact(1),
+            Some(
+                "\
+                 Returns the base 10 logarithm of a number.",
+            ),
+        ).add_function(
+            "radians",
+            fn_radians,
+            Exact(1),
+            Some("Converts a value in degrees to radians."),
+        ).add_function(
+            "sin",
+            fn_sin,
+            Exact(1),
+            Some("Computes the sine of a number, in radians."),
+        ).add_function("sinh", fn_sinh, Exact(1), Some("Hyperbolic sine function."))
+        .add_function(
+            "sqrt",
+            fn_sqrt,
+            Exact(1),
+            Some(
+                "\
 Returns the square root of a number.
-Returns `NaN` if the number is negative."))
-        .add_function("tan",        fn_tan,     Exact(1),
-            Some("Computes the tangent of a number, in radians."))
-        .add_function("tanh",       fn_tanh,    Exact(1),
-            Some("Hyperbolic tangent function"))
-        .finish()
+Returns `NaN` if the number is negative.",
+            ),
+        ).add_function(
+            "tan",
+            fn_tan,
+            Exact(1),
+            Some("Computes the tangent of a number, in radians."),
+        ).add_function(
+            "tanh",
+            fn_tanh,
+            Exact(1),
+            Some("Hyperbolic tangent function"),
+        ).finish()
 }
 
 /// `acos` returns the arccosine of a number. Return value is in radians
@@ -204,6 +286,6 @@ fn get_float(v: &Value) -> Result<f64, ExecError> {
         Value::Float(f) => Ok(f),
         Value::Integer(ref i) => i.to_f64().ok_or(ExecError::Overflow),
         Value::Ratio(ref r) => r.to_f64().ok_or(ExecError::Overflow),
-        ref v => Err(ExecError::expected("number", v))
+        ref v => Err(ExecError::expected("number", v)),
     }
 }

--- a/src/ketos/mod_random.rs
+++ b/src/ketos/mod_random.rs
@@ -12,11 +12,17 @@ use value::Value;
 /// Loads the `random` module into the given scope.
 pub fn load(scope: Scope) -> Module {
     ModuleBuilder::new("random", scope)
-        .add_function("random",  fn_random,  Exact(0),
-            Some("Returns a random float value in the range `[0.0, 1.0)`."))
-        .add_function("shuffle", fn_shuffle, Exact(1),
-            Some("Given a list, returns a new list with the elements shuffled."))
-        .finish()
+        .add_function(
+            "random",
+            fn_random,
+            Exact(0),
+            Some("Returns a random float value in the range `[0.0, 1.0)`."),
+        ).add_function(
+            "shuffle",
+            fn_shuffle,
+            Exact(1),
+            Some("Given a list, returns a new list with the elements shuffled."),
+        ).finish()
 }
 
 /// `random` returns a random float value in the range `[0.0, 1.0)`.
@@ -32,7 +38,7 @@ fn fn_shuffle(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match v {
         Value::Unit => (),
         Value::List(ref mut li) => thread_rng().shuffle(li),
-        ref v => return Err(From::from(ExecError::expected("list", v)))
+        ref v => return Err(From::from(ExecError::expected("list", v))),
     }
 
     Ok(v)

--- a/src/ketos/module.rs
+++ b/src/ketos/module.rs
@@ -8,9 +8,9 @@ use std::rc::Rc;
 
 use bytecode::Code;
 use compile::{compile, CompileError};
-use encode::{DecodeError, read_bytecode_file, write_bytecode_file};
+use encode::{read_bytecode_file, write_bytecode_file, DecodeError};
 use error::Error;
-use exec::{Context, execute};
+use exec::{execute, Context};
 use function::{Arity, Function, FunctionImpl, Lambda, SystemFn};
 use io::{IoError, IoMode};
 use lexer::Lexer;
@@ -36,7 +36,7 @@ impl Module {
     /// Creates a new module using the given scope.
     pub fn new(name: &str, scope: Scope) -> Module {
         let name = scope.add_name(name);
-        Module{
+        Module {
             name: name,
             scope: scope,
         }
@@ -55,7 +55,7 @@ impl ModuleBuilder {
     pub fn new(name: &str, scope: Scope) -> ModuleBuilder {
         let mod_name = scope.borrow_names_mut().add(name);
 
-        ModuleBuilder{
+        ModuleBuilder {
             name: mod_name,
             scope: scope.clone(),
         }
@@ -76,16 +76,23 @@ impl ModuleBuilder {
     }
 
     /// Adds a function to the module.
-    pub fn add_function(self, name: &str,
-            callback: FunctionImpl, arity: Arity, doc: Option<&'static str>) -> Self {
-        self.add_value_with_name(name, |name| Value::Function(Function{
+    pub fn add_function(
+        self,
+        name: &str,
+        callback: FunctionImpl,
+        arity: Arity,
+        doc: Option<&'static str>,
+    ) -> Self {
+        self.add_value_with_name(name, |name| {
+            Value::Function(Function {
                 name: name,
-                sys_fn: SystemFn{
+                sys_fn: SystemFn {
                     arity: arity,
                     callback: callback,
                     doc: doc,
                 },
-            }))
+            })
+        })
     }
 
     /// Adds a value to the module.
@@ -96,7 +103,9 @@ impl ModuleBuilder {
 
     /// Adds a value to the module using the generated name value.
     pub fn add_value_with_name<F>(self, name: &str, f: F) -> Self
-            where F: FnOnce(Name) -> Value {
+    where
+        F: FnOnce(Name) -> Value,
+    {
         self.scope.add_value_with_name(name, f);
         self
     }
@@ -105,16 +114,16 @@ impl ModuleBuilder {
     pub fn finish(self) -> Module {
         let mut exports = Vec::new();
 
-        self.scope.with_constants(
-            |v| exports.extend(v.iter().map(|&(name, _)| name)));
-        self.scope.with_macros(
-            |v| exports.extend(v.iter().map(|&(name, _)| name)));
-        self.scope.with_values(
-            |v| exports.extend(v.iter().map(|&(name, _)| name)));
+        self.scope
+            .with_constants(|v| exports.extend(v.iter().map(|&(name, _)| name)));
+        self.scope
+            .with_macros(|v| exports.extend(v.iter().map(|&(name, _)| name)));
+        self.scope
+            .with_values(|v| exports.extend(v.iter().map(|&(name, _)| name)));
 
         self.scope.set_exports(exports.into_iter().collect());
 
-        Module{
+        Module {
             name: self.name,
             scope: self.scope,
         }
@@ -150,31 +159,40 @@ impl ModuleCode {
         fn is_lambda(v: &Value) -> bool {
             match *v {
                 Value::Lambda(_) => true,
-                _ => false
+                _ => false,
             }
         }
 
         code.retain(|code| !code.is_trivial());
 
-        ModuleCode{
+        ModuleCode {
             code: code,
-            constants: scope.with_constants(
-                |consts| consts.iter().cloned().collect()),
-            macros: scope.with_macros(
-                |macros| macros.iter()
-                    .map(|&(name, ref l)| (name, l.code.clone())).collect()),
-            values: scope.with_values(
-                |values| values.iter()
+            constants: scope.with_constants(|consts| consts.iter().cloned().collect()),
+            macros: scope.with_macros(|macros| {
+                macros
+                    .iter()
+                    .map(|&(name, ref l)| (name, l.code.clone()))
+                    .collect()
+            }),
+            values: scope.with_values(|values| {
+                values
+                    .iter()
                     .filter(|&&(_, ref v)| is_lambda(v))
                     .filter(|&&(name, _)| !scope.is_imported(name))
-                    .map(|pair| pair.clone()).collect()),
-            exports: scope.with_exports(|e| e.clone())
+                    .map(|pair| pair.clone())
+                    .collect()
+            }),
+            exports: scope
+                .with_exports(|e| e.clone())
                 .unwrap_or_else(NameSetSlice::default),
             imports: scope.with_imports(|i| i.to_vec()),
             module_doc: scope.with_module_doc(|d| d.to_owned()),
-            docs: scope.with_docs(
-                |d| d.iter().filter(|&&(name, _)| !scope.is_imported(name))
-                    .cloned().collect()),
+            docs: scope.with_docs(|d| {
+                d.iter()
+                    .filter(|&&(name, _)| !scope.is_imported(name))
+                    .cloned()
+                    .collect()
+            }),
         }
     }
 
@@ -201,7 +219,8 @@ impl ModuleCode {
         let mdoc = self.module_doc;
         ctx.scope().with_module_doc_mut(|d| *d = mdoc);
         let docs = self.docs;
-        ctx.scope().with_docs_mut(|d| *d = docs.into_iter().collect());
+        ctx.scope()
+            .with_docs_mut(|d| *d = docs.into_iter().collect());
 
         for code in self.code {
             execute(ctx, code)?;
@@ -221,7 +240,7 @@ impl ModuleRegistry {
     /// Creates a new `ModuleRegistry` using the given `ModuleLoader`
     /// to load new modules.
     pub fn new(loader: Box<ModuleLoader>) -> ModuleRegistry {
-        ModuleRegistry{
+        ModuleRegistry {
             loader: loader,
             modules: RefCell::new(NameMap::new()),
         }
@@ -272,8 +291,10 @@ pub trait ModuleLoader {
     /// falling back on the supplied `ModuleLoader` if it unable to find a
     /// module.
     fn chain<T: ModuleLoader>(self, second: T) -> ChainModuleLoader<Self, T>
-            where Self: Sized {
-        ChainModuleLoader{
+    where
+        Self: Sized,
+    {
+        ChainModuleLoader {
             first: self,
             second: second,
         }
@@ -304,14 +325,18 @@ pub struct ChainModuleLoader<A, B> {
 }
 
 impl<A, B> ModuleLoader for ChainModuleLoader<A, B>
-        where A: ModuleLoader, B: ModuleLoader {
+where
+    A: ModuleLoader,
+    B: ModuleLoader,
+{
     fn load_module(&self, name: Name, ctx: Context) -> Result<Module, Error> {
         match self.first.load_module(name, ctx.clone()) {
             // Check that the names match so we know that this module lookup
             // failed and not another contained module being imported.
-            Err(Error::CompileError(CompileError::ModuleError(mname)))
-                if mname == name => self.second.load_module(name, ctx),
-            res => res
+            Err(Error::CompileError(CompileError::ModuleError(mname))) if mname == name => {
+                self.second.load_module(name, ctx)
+            }
+            res => res,
         }
     }
 }
@@ -330,7 +355,7 @@ fn get_loader(name: &str) -> Option<fn(Scope) -> Module> {
         "code" => Some(mod_code::load),
         "math" => Some(mod_math::load),
         "random" => Some(mod_random::load),
-        _ => None
+        _ => None,
     }
 }
 
@@ -339,7 +364,7 @@ fn load_builtin_module(name: Name, scope: &Scope) -> Result<Module, Error> {
 
     match loader {
         Some(l) => Ok(l(scope.clone())),
-        None => Err(From::from(CompileError::ModuleError(name)))
+        None => Err(From::from(CompileError::ModuleError(name))),
     }
 }
 
@@ -371,7 +396,7 @@ impl FileModuleLoader {
     /// Creates a new `FileModuleLoader` that will search the given series
     /// of directories to load modules.
     pub fn with_search_paths(paths: Vec<PathBuf>) -> FileModuleLoader {
-        FileModuleLoader{
+        FileModuleLoader {
             chain: RefCell::new(Vec::new()),
             paths: paths,
             read_bytecode: true,
@@ -397,7 +422,9 @@ impl FileModuleLoader {
     }
 
     fn guard_import<F, T>(&self, name: Name, path: &Path, f: F) -> Result<T, Error>
-            where F: FnOnce() -> Result<T, Error> {
+    where
+        F: FnOnce() -> Result<T, Error>,
+    {
         if self.chain.borrow().iter().any(|p| p == path) {
             return Err(From::from(CompileError::ImportCycle(name)));
         }
@@ -416,8 +443,10 @@ impl ModuleLoader for FileModuleLoader {
             if name_str.chars().any(|c| c == '.' || c == '/' || c == '\\') {
                 Err(CompileError::InvalidModuleName(name))
             } else {
-                Ok((PathBuf::from(format!("{}.{}", name_str, FILE_EXTENSION)),
-                    PathBuf::from(format!("{}.{}", name_str, COMPILED_FILE_EXTENSION))))
+                Ok((
+                    PathBuf::from(format!("{}.{}", name_str, FILE_EXTENSION)),
+                    PathBuf::from(format!("{}.{}", name_str, COMPILED_FILE_EXTENSION)),
+                ))
             }
         })?;
 
@@ -438,23 +467,23 @@ impl ModuleLoader for FileModuleLoader {
                             Ok(m) => {
                                 m.load_in_context(&ctx)?;
 
-                                Ok(Module{
+                                Ok(Module {
                                     name: name,
                                     scope: ctx.scope().clone(),
                                 })
                             }
                             Err(Error::DecodeError(DecodeError::IncorrectVersion(_)))
-                                    if src_path.exists() => {
+                                if src_path.exists() =>
+                            {
                                 let code_path = if self.write_bytecode {
                                     Some(code_path.as_path())
                                 } else {
                                     None
                                 };
 
-                                load_module_from_file(ctx, name,
-                                    &src_path, code_path)
+                                load_module_from_file(ctx, name, &src_path, code_path)
                             }
-                            Err(e) => Err(e)
+                            Err(e) => Err(e),
                         }
                     });
                 }
@@ -465,10 +494,11 @@ impl ModuleLoader for FileModuleLoader {
                         None
                     };
 
-                    return self.guard_import(name, &src_path,
-                        || load_module_from_file(ctx, name, &src_path, code_path))
+                    return self.guard_import(name, &src_path, || {
+                        load_module_from_file(ctx, name, &src_path, code_path)
+                    });
                 }
-                ModuleFileResult::NotFound => ()
+                ModuleFileResult::NotFound => (),
             }
         }
 
@@ -485,11 +515,10 @@ enum ModuleFileResult {
 
 fn find_module_file(src_path: &Path, code_path: &Path) -> Result<ModuleFileResult, Error> {
     match (code_path.exists(), src_path.exists()) {
-        (true, true) if is_younger(code_path, src_path)? =>
-            Ok(ModuleFileResult::UseCode),
+        (true, true) if is_younger(code_path, src_path)? => Ok(ModuleFileResult::UseCode),
         (_, true) => Ok(ModuleFileResult::UseSource),
         (true, false) => Ok(ModuleFileResult::UseCode),
-        (false, false) => Ok(ModuleFileResult::NotFound)
+        (false, false) => Ok(ModuleFileResult::NotFound),
     }
 }
 
@@ -502,10 +531,8 @@ fn find_source_file(src_path: &Path) -> ModuleFileResult {
 }
 
 fn is_younger(a: &Path, b: &Path) -> Result<bool, Error> {
-    let ma = a.metadata()
-        .map_err(|e| IoError::new(IoMode::Stat, a, e))?;
-    let mb = b.metadata()
-        .map_err(|e| IoError::new(IoMode::Stat, b, e))?;
+    let ma = a.metadata().map_err(|e| IoError::new(IoMode::Stat, a, e))?;
+    let mb = b.metadata().map_err(|e| IoError::new(IoMode::Stat, b, e))?;
 
     Ok(is_younger_impl(&ma, &mb))
 }
@@ -522,24 +549,31 @@ fn is_younger_impl(ma: &Metadata, mb: &Metadata) -> bool {
     ma.last_write_time() > mb.last_write_time()
 }
 
-fn load_module_from_file(ctx: Context, name: Name,
-        src_path: &Path, code_path: Option<&Path>) -> Result<Module, Error> {
-    let mut file = File::open(src_path)
-        .map_err(|e| IoError::new(IoMode::Open, src_path, e))?;
+fn load_module_from_file(
+    ctx: Context,
+    name: Name,
+    src_path: &Path,
+    code_path: Option<&Path>,
+) -> Result<Module, Error> {
+    let mut file = File::open(src_path).map_err(|e| IoError::new(IoMode::Open, src_path, e))?;
     let mut buf = String::new();
 
     file.read_to_string(&mut buf)
         .map_err(|e| IoError::new(IoMode::Read, src_path, e))?;
 
     let exprs = {
-        let offset = ctx.scope().borrow_codemap_mut().add_source(&buf,
-            Some(src_path.to_string_lossy().into_owned()));
+        let offset = ctx
+            .scope()
+            .borrow_codemap_mut()
+            .add_source(&buf, Some(src_path.to_string_lossy().into_owned()));
 
         Parser::new(&ctx, Lexer::new(&buf, offset)).parse_exprs()?
     };
 
-    let code = exprs.iter()
-        .map(|e| compile(&ctx, e).map(Rc::new)).collect::<Result<Vec<_>, _>>()?;
+    let code = exprs
+        .iter()
+        .map(|e| compile(&ctx, e).map(Rc::new))
+        .collect::<Result<Vec<_>, _>>()?;
 
     if let Some(code_path) = code_path {
         // Grab compile-time values before executing code
@@ -567,7 +601,7 @@ fn load_module_from_file(ctx: Context, name: Name,
         check_exports(ctx.scope(), name)?;
     }
 
-    Ok(Module{
+    Ok(Module {
         name: name,
         scope: ctx.scope().clone(),
     })
@@ -581,12 +615,12 @@ fn process_imports(ctx: &Context, imports: &[ImportSet]) -> Result<(), Error> {
 
         for &(src, dest) in &imp.names {
             if !m.scope.contains_name(src) {
-                return Err(From::from(CompileError::ImportError{
+                return Err(From::from(CompileError::ImportError {
                     module: imp.module_name,
                     name: src,
                 }));
             } else if !m.scope.is_exported(src) {
-                return Err(From::from(CompileError::PrivacyError{
+                return Err(From::from(CompileError::PrivacyError {
                     module: imp.module_name,
                     name: src,
                 }));
@@ -607,7 +641,8 @@ fn process_imports(ctx: &Context, imports: &[ImportSet]) -> Result<(), Error> {
                 ctx.scope().add_value(dest, v);
             }
 
-            m.scope.with_doc(src, |d| ctx.scope().add_doc_string(dest, d.to_owned()));
+            m.scope
+                .with_doc(src, |d| ctx.scope().add_doc_string(dest, d.to_owned()));
         }
     }
 
@@ -615,24 +650,25 @@ fn process_imports(ctx: &Context, imports: &[ImportSet]) -> Result<(), Error> {
 }
 
 fn check_exports(scope: &Scope, mod_name: Name) -> Result<(), CompileError> {
-    scope.with_exports(|exports| {
-        for name in exports {
-            if !scope.contains_name(name) {
-                return Err(CompileError::ExportError{
-                    module: mod_name,
-                    name: name,
-                });
+    scope
+        .with_exports(|exports| {
+            for name in exports {
+                if !scope.contains_name(name) {
+                    return Err(CompileError::ExportError {
+                        module: mod_name,
+                        name: name,
+                    });
+                }
             }
-        }
 
-        Ok(())
-    }).ok_or(CompileError::MissingExport)
+            Ok(())
+        }).ok_or(CompileError::MissingExport)
         .and_then(|r| r)
 }
 
 #[cfg(test)]
 mod test {
-    use super::{ModuleLoader, BuiltinModuleLoader, NullModuleLoader};
+    use super::{BuiltinModuleLoader, ModuleLoader, NullModuleLoader};
 
     #[test]
     fn test_chain_loader() {

--- a/src/ketos/name.rs
+++ b/src/ketos/name.rs
@@ -235,8 +235,7 @@ pub const SYSTEM_OPERATORS_BEGIN: u32 = NUM_STANDARD_VALUES;
 pub const SYSTEM_OPERATORS_END: u32 = 83;
 
 /// Number of system operators, beginning at `SYSTEM_OPERATORS_BEGIN`.
-pub const NUM_SYSTEM_OPERATORS: usize =
-    (SYSTEM_OPERATORS_END - SYSTEM_OPERATORS_BEGIN) as usize;
+pub const NUM_SYSTEM_OPERATORS: usize = (SYSTEM_OPERATORS_END - SYSTEM_OPERATORS_BEGIN) as usize;
 
 /// Represents a value which can produce debugging output and may contain
 /// one or more interned `Name` values.
@@ -319,7 +318,7 @@ pub struct NameInputConversion {
 impl NameInputConversion {
     /// Creates a new `NameInputConversion` from a local-to-global mapping.
     pub fn new() -> NameInputConversion {
-        NameInputConversion{
+        NameInputConversion {
             map: HashMap::new(),
             next_value: NUM_STANDARD_NAMES,
         }
@@ -344,14 +343,14 @@ pub struct NameOutputConversion<'a> {
     /// Name strings, mapped to local name values
     names: Vec<&'a str>,
     map: HashMap<Name, u32>,
-    store: &'a NameStore
+    store: &'a NameStore,
 }
 
 impl<'a> NameOutputConversion<'a> {
     /// Creates a new `NameOutputConversion`, using the given `NameStore`
     /// to lookup global name values.
     pub fn new(store: &NameStore) -> NameOutputConversion {
-        NameOutputConversion{
+        NameOutputConversion {
             names: Vec::new(),
             map: HashMap::new(),
             store: store,
@@ -400,9 +399,7 @@ pub struct NameStore {
 impl NameStore {
     /// Constructs an empty `NameStore`.
     pub fn new() -> NameStore {
-        NameStore{
-            names: Vec::new(),
-        }
+        NameStore { names: Vec::new() }
     }
 
     /// Adds a name to the `NameStore` if it is not present.
@@ -434,9 +431,11 @@ impl NameStore {
             "<dummy name>"
         } else {
             standard_name(name)
-                .or_else(|| self.names.get((name.0 - NUM_STANDARD_NAMES) as usize)
-                    .map(|s| &s[..]))
-                .unwrap_or("<invalid name>")
+                .or_else(|| {
+                    self.names
+                        .get((name.0 - NUM_STANDARD_NAMES) as usize)
+                        .map(|s| &s[..])
+                }).unwrap_or("<invalid name>")
         }
     }
 
@@ -494,7 +493,7 @@ pub struct NameMap<T> {
 impl<T> NameMap<T> {
     /// Returns a new `NameMap`.
     pub fn new() -> NameMap<T> {
-        NameMap{values: Vec::new()}
+        NameMap { values: Vec::new() }
     }
 
     /// Lowers the map into a `NameMapSlice`, which may not receive new
@@ -510,13 +509,17 @@ impl<T> NameMap<T> {
 
     /// Returns whether the map contains a value for the given name.
     pub fn contains_key(&self, name: Name) -> bool {
-        self.values.binary_search_by(|&(ref n, _)| n.cmp(&name)).is_ok()
+        self.values
+            .binary_search_by(|&(ref n, _)| n.cmp(&name))
+            .is_ok()
     }
 
     /// Returns the value corresponding to the given name.
     pub fn get(&self, name: Name) -> Option<&T> {
-        self.values.binary_search_by(|&(ref n, _)| n.cmp(&name))
-            .ok().map(|pos| &self.values[pos].1)
+        self.values
+            .binary_search_by(|&(ref n, _)| n.cmp(&name))
+            .ok()
+            .map(|pos| &self.values[pos].1)
     }
 
     /// Returns a slice of the contained names and values.
@@ -556,10 +559,13 @@ impl<T> NameMap<T> {
 }
 
 impl<T> FromIterator<(Name, T)> for NameMap<T> {
-    fn from_iter<I>(iterator: I) -> Self where I: IntoIterator<Item=(Name, T)> {
+    fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = (Name, T)>,
+    {
         let mut v = iterator.into_iter().collect::<Vec<_>>();
         v.sort_by(|a, b| a.0.cmp(&b.0));
-        NameMap{values: v}
+        NameMap { values: v }
     }
 }
 
@@ -584,7 +590,7 @@ impl<T> NameMapSlice<T> {
     /// Creates a `NameMapSlice` wrapping the given boxed slice,
     /// which must already be sorted by name.
     fn new(values: Box<[(Name, T)]>) -> NameMapSlice<T> {
-        NameMapSlice{values: values}
+        NameMapSlice { values: values }
     }
 
     /// Returns whether the map contains a value for the given name.
@@ -599,8 +605,10 @@ impl<T> NameMapSlice<T> {
 
     /// Returns the value corresponding to the given name.
     pub fn get(&self, name: Name) -> Option<&T> {
-        self.values.binary_search_by(|&(n, _)| n.cmp(&name))
-            .ok().map(|pos| &self.values[pos].1)
+        self.values
+            .binary_search_by(|&(n, _)| n.cmp(&name))
+            .ok()
+            .map(|pos| &self.values[pos].1)
     }
 
     /// Returns a slice of the contained names and values.
@@ -615,7 +623,7 @@ impl<T> NameMapSlice<T> {
     pub fn set(&mut self, name: Name, value: T) -> Option<T> {
         match self.values.binary_search_by(|&(n, _)| n.cmp(&name)) {
             Ok(n) => Some(replace(&mut self.values[n].1, value)),
-            Err(_) => None
+            Err(_) => None,
         }
     }
 
@@ -631,7 +639,9 @@ impl<T> NameMapSlice<T> {
 
     /// Elevates the map into `NameMap`, which may receive new key-value pairs.
     pub fn into_name_map(self) -> NameMap<T> {
-        NameMap{values: self.values.into_vec()}
+        NameMap {
+            values: self.values.into_vec(),
+        }
     }
 
     /// Returns the number of name-value pairs contained in the map.
@@ -641,7 +651,10 @@ impl<T> NameMapSlice<T> {
 }
 
 impl<T> FromIterator<(Name, T)> for NameMapSlice<T> {
-    fn from_iter<I>(iterator: I) -> Self where I: IntoIterator<Item=(Name, T)> {
+    fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = (Name, T)>,
+    {
         iterator.into_iter().collect::<NameMap<_>>().into_slice()
     }
 }
@@ -664,7 +677,9 @@ pub struct NameSet {
 impl NameSet {
     /// Returns a new `NameSet`.
     pub fn new() -> NameSet {
-        NameSet{map: NameMap::new()}
+        NameSet {
+            map: NameMap::new(),
+        }
     }
 
     /// Removes all names from the set.
@@ -705,8 +720,13 @@ impl NameSet {
 }
 
 impl FromIterator<Name> for NameSet {
-    fn from_iter<I>(iterator: I) -> Self where I: IntoIterator<Item=Name> {
-        NameSet{map: iterator.into_iter().map(|n| (n, ())).collect()}
+    fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = Name>,
+    {
+        NameSet {
+            map: iterator.into_iter().map(|n| (n, ())).collect(),
+        }
     }
 }
 
@@ -731,7 +751,7 @@ impl NameSetSlice {
     /// Creates a `NameSetSlice` wrapping the given boxed slice,
     /// which must already be sorted.
     fn new(map: NameMapSlice<()>) -> NameSetSlice {
-        NameSetSlice{map: map}
+        NameSetSlice { map: map }
     }
 
     /// Returns whether the set contains the given name.
@@ -741,7 +761,9 @@ impl NameSetSlice {
 
     /// Elevates the set into a `NameSet`, which may receive new name values.
     pub fn into_name_set(self) -> NameSet {
-        NameSet{map: self.map.into_name_map()}
+        NameSet {
+            map: self.map.into_name_map(),
+        }
     }
 
     /// Returns whether the set is empty.
@@ -761,7 +783,10 @@ impl NameSetSlice {
 }
 
 impl FromIterator<Name> for NameSetSlice {
-    fn from_iter<I>(iterator: I) -> Self where I: IntoIterator<Item=Name> {
+    fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = Name>,
+    {
         iterator.into_iter().collect::<NameSet>().into_slice()
     }
 }

--- a/src/ketos/pretty.rs
+++ b/src/ketos/pretty.rs
@@ -18,7 +18,7 @@ pub fn pretty_print<W: Write>(w: &mut W, names: &NameStore, v: &Value, indent: u
 
             let sub_indent = match *first {
                 Value::Name(_) => indent + 2,
-                _ => indent + 1
+                _ => indent + 1,
             };
 
             w.write_char('(')?;
@@ -47,17 +47,15 @@ pub fn pretty_print<W: Write>(w: &mut W, names: &NameStore, v: &Value, indent: u
 
             w.write_char(')')
         }
-        _ => write!(w, "{}", debug_names(names, v))
+        _ => write!(w, "{}", debug_names(names, v)),
     }
 }
 
 fn is_short_args(args: &[Value]) -> bool {
-    args.len() <= 5 && args.iter().all(|v| {
-        match *v {
-            Value::List(_) => false,
-            Value::String(ref s) if s.len() > 15 => false,
-            _ => true
-        }
+    args.len() <= 5 && args.iter().all(|v| match *v {
+        Value::List(_) => false,
+        Value::String(ref s) if s.len() > 15 => false,
+        _ => true,
     })
 }
 

--- a/src/ketos/rc_vec.rs
+++ b/src/ketos/rc_vec.rs
@@ -13,21 +13,33 @@ use std::slice::Iter;
 /// Argument for functions accepting a range
 pub trait RangeArgument<T> {
     /// Returns start value
-    fn start(&self) -> Option<&T> { None }
+    fn start(&self) -> Option<&T> {
+        None
+    }
     /// Returns end value
-    fn end(&self) -> Option<&T> { None }
+    fn end(&self) -> Option<&T> {
+        None
+    }
 }
 
 impl<T> RangeArgument<T> for ops::RangeFull {}
 impl<T> RangeArgument<T> for ops::Range<T> {
-    fn start(&self) -> Option<&T> { Some(&self.start) }
-    fn end(&self) -> Option<&T> { Some(&self.end) }
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
 }
 impl<T> RangeArgument<T> for ops::RangeFrom<T> {
-    fn start(&self) -> Option<&T> { Some(&self.start) }
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
 }
 impl<T> RangeArgument<T> for ops::RangeTo<T> {
-    fn end(&self) -> Option<&T> { Some(&self.end) }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
 }
 
 /// Represents a reference-counted view into a `String`.
@@ -44,7 +56,7 @@ impl RcString {
     pub fn new(data: String) -> RcString {
         let n = data.len();
 
-        RcString{
+        RcString {
             data: Rc::new(data),
             start: 0,
             end: n,
@@ -70,21 +82,32 @@ impl RcString {
         let b = self.start + end;
 
         if a > self.end {
-            panic!("RcString slice out of bounds; start is {} but length is {}",
-                start, self.len());
+            panic!(
+                "RcString slice out of bounds; start is {} but length is {}",
+                start,
+                self.len()
+            );
         }
 
         if b > self.end {
-            panic!("RcString slice out of bounds; end is {} but length is {}",
-                end, self.len());
+            panic!(
+                "RcString slice out of bounds; end is {} but length is {}",
+                end,
+                self.len()
+            );
         }
 
         if !self.data.is_char_boundary(a) || !self.data.is_char_boundary(b) {
-            panic!("index {} and/or {} in RcString `{}` do not lie on \
-                character boundary", a, b, &self[..]);
+            panic!(
+                "index {} and/or {} in RcString `{}` do not lie on \
+                 character boundary",
+                a,
+                b,
+                &self[..]
+            );
         }
 
-        RcString{
+        RcString {
             data: self.data.clone(),
             start: a,
             end: b,
@@ -99,7 +122,7 @@ impl RcString {
                 let _ = s.drain(..self.start);
                 s
             }
-            Err(data) => data[self.start..self.end].to_owned()
+            Err(data) => data[self.start..self.end].to_owned(),
         }
     }
 
@@ -182,10 +205,14 @@ impl fmt::Display for RcString {
 macro_rules! impl_eq_str {
     ( $lhs:ty, $rhs:ty ) => {
         impl<'a> PartialEq<$rhs> for $lhs {
-            fn eq(&self, rhs: &$rhs) -> bool { self[..] == rhs[..] }
-            fn ne(&self, rhs: &$rhs) -> bool { self[..] != rhs[..] }
+            fn eq(&self, rhs: &$rhs) -> bool {
+                self[..] == rhs[..]
+            }
+            fn ne(&self, rhs: &$rhs) -> bool {
+                self[..] != rhs[..]
+            }
         }
-    }
+    };
 }
 
 impl_eq_str!{ RcString, RcString }
@@ -197,16 +224,28 @@ impl_eq_str!{ RcString, Cow<'a, str> }
 impl Eq for RcString {}
 
 impl PartialOrd for RcString {
-    fn partial_cmp(&self, rhs: &RcString) -> Option<Ordering> { self[..].partial_cmp(&rhs[..]) }
+    fn partial_cmp(&self, rhs: &RcString) -> Option<Ordering> {
+        self[..].partial_cmp(&rhs[..])
+    }
 
-    fn lt(&self, rhs: &RcString) -> bool { self[..] < rhs[..] }
-    fn le(&self, rhs: &RcString) -> bool { self[..] <= rhs[..] }
-    fn gt(&self, rhs: &RcString) -> bool { self[..] > rhs[..] }
-    fn ge(&self, rhs: &RcString) -> bool { self[..] >= rhs[..] }
+    fn lt(&self, rhs: &RcString) -> bool {
+        self[..] < rhs[..]
+    }
+    fn le(&self, rhs: &RcString) -> bool {
+        self[..] <= rhs[..]
+    }
+    fn gt(&self, rhs: &RcString) -> bool {
+        self[..] > rhs[..]
+    }
+    fn ge(&self, rhs: &RcString) -> bool {
+        self[..] >= rhs[..]
+    }
 }
 
 impl Ord for RcString {
-    fn cmp(&self, rhs: &RcString) -> Ordering { self[..].cmp(&rhs[..]) }
+    fn cmp(&self, rhs: &RcString) -> Ordering {
+        self[..].cmp(&rhs[..])
+    }
 }
 
 impl<'a> From<&'a str> for RcString {
@@ -235,7 +274,7 @@ impl<T> RcVec<T> {
     pub fn new(data: Vec<T>) -> RcVec<T> {
         let n = data.len();
 
-        RcVec{
+        RcVec {
             data: Rc::new(data),
             start: 0,
             end: n,
@@ -262,16 +301,22 @@ impl<T> RcVec<T> {
         let b = self.start + end;
 
         if a > self.end {
-            panic!("RcVec slice out of bounds; start is {} but length is {}",
-                start, self.len());
+            panic!(
+                "RcVec slice out of bounds; start is {} but length is {}",
+                start,
+                self.len()
+            );
         }
 
         if b > self.end {
-            panic!("RcVec slice out of bounds; end is {} but length is {}",
-                end, self.len());
+            panic!(
+                "RcVec slice out of bounds; end is {} but length is {}",
+                end,
+                self.len()
+            );
         }
 
-        RcVec{
+        RcVec {
             data: self.data.clone(),
             start: a,
             end: b,
@@ -289,7 +334,7 @@ impl<T: Clone> RcVec<T> {
                 let _ = v.drain(..self.start);
                 v
             }
-            Err(data) => data[self.start..self.end].to_vec()
+            Err(data) => data[self.start..self.end].to_vec(),
         }
     }
 
@@ -347,14 +392,23 @@ impl<T: fmt::Debug> fmt::Debug for RcVec<T> {
 }
 
 impl<T: Clone> Extend<T> for RcVec<T> {
-    fn extend<I>(&mut self, iterable: I) where I: IntoIterator<Item=T> {
+    fn extend<I>(&mut self, iterable: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
         self.make_mut().extend(iterable);
         self.end = self.data.len();
     }
 }
 
-impl<'a, T: Clone> Extend<&'a T> for RcVec<T> where T: Copy + 'a {
-    fn extend<I>(&mut self, iterable: I) where I: IntoIterator<Item=&'a T> {
+impl<'a, T: Clone> Extend<&'a T> for RcVec<T>
+where
+    T: Copy + 'a,
+{
+    fn extend<I>(&mut self, iterable: I)
+    where
+        I: IntoIterator<Item = &'a T>,
+    {
         self.make_mut().extend(iterable);
         self.end = self.data.len();
     }
@@ -371,11 +425,18 @@ impl<'a, T> IntoIterator for &'a RcVec<T> {
 
 macro_rules! impl_eq_vec {
     ( $lhs:ty, $rhs:ty ) => {
-        impl<'a, A, B> PartialEq<$rhs> for $lhs where A: PartialEq<B> {
-            fn eq(&self, rhs: &$rhs) -> bool { self[..] == rhs[..] }
-            fn ne(&self, rhs: &$rhs) -> bool { self[..] != rhs[..] }
+        impl<'a, A, B> PartialEq<$rhs> for $lhs
+        where
+            A: PartialEq<B>,
+        {
+            fn eq(&self, rhs: &$rhs) -> bool {
+                self[..] == rhs[..]
+            }
+            fn ne(&self, rhs: &$rhs) -> bool {
+                self[..] != rhs[..]
+            }
         }
-    }
+    };
 }
 
 macro_rules! impl_eq_array {
@@ -407,16 +468,28 @@ impl_eq_array!{
 impl<T: Eq> Eq for RcVec<T> {}
 
 impl<T: PartialOrd> PartialOrd for RcVec<T> {
-    fn partial_cmp(&self, rhs: &RcVec<T>) -> Option<Ordering> { self[..].partial_cmp(&rhs[..]) }
+    fn partial_cmp(&self, rhs: &RcVec<T>) -> Option<Ordering> {
+        self[..].partial_cmp(&rhs[..])
+    }
 
-    fn lt(&self, rhs: &RcVec<T>) -> bool { self[..] < rhs[..] }
-    fn le(&self, rhs: &RcVec<T>) -> bool { self[..] <= rhs[..] }
-    fn gt(&self, rhs: &RcVec<T>) -> bool { self[..] > rhs[..] }
-    fn ge(&self, rhs: &RcVec<T>) -> bool { self[..] >= rhs[..] }
+    fn lt(&self, rhs: &RcVec<T>) -> bool {
+        self[..] < rhs[..]
+    }
+    fn le(&self, rhs: &RcVec<T>) -> bool {
+        self[..] <= rhs[..]
+    }
+    fn gt(&self, rhs: &RcVec<T>) -> bool {
+        self[..] > rhs[..]
+    }
+    fn ge(&self, rhs: &RcVec<T>) -> bool {
+        self[..] >= rhs[..]
+    }
 }
 
 impl<T: Ord> Ord for RcVec<T> {
-    fn cmp(&self, rhs: &RcVec<T>) -> Ordering { self[..].cmp(&rhs[..]) }
+    fn cmp(&self, rhs: &RcVec<T>) -> Ordering {
+        self[..].cmp(&rhs[..])
+    }
 }
 
 impl<T> From<Vec<T>> for RcVec<T> {

--- a/src/ketos/restrict.rs
+++ b/src/ketos/restrict.rs
@@ -129,7 +129,7 @@ impl RestrictConfig {
     ///
     /// No restrictions are placed on executing code.
     pub fn permissive() -> RestrictConfig {
-        RestrictConfig{
+        RestrictConfig {
             execution_time: None,
             call_stack_size: PERMISSIVE_CALL_STACK_SIZE,
             value_stack_size: PERMISSIVE_VALUE_STACK_SIZE,
@@ -145,7 +145,7 @@ impl RestrictConfig {
     /// Small programs with short runtimes should not have a problem operating
     /// within these restrictions.
     pub fn strict() -> RestrictConfig {
-        RestrictConfig{
+        RestrictConfig {
             execution_time: Some(Duration::from_millis(100)),
             call_stack_size: STRICT_CALL_STACK_SIZE,
             value_stack_size: STRICT_VALUE_STACK_SIZE,

--- a/src/ketos/run.rs
+++ b/src/ketos/run.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use compile::compile;
 use error::Error;
-use exec::{Context, execute};
+use exec::{execute, Context};
 use lexer::Lexer;
 use parser::Parser;
 use value::Value;
@@ -19,7 +19,8 @@ pub fn run_code(ctx: &Context, input: &str) -> Result<Value, Error> {
         p.parse_exprs()?
     };
 
-    let code = exprs.iter()
+    let code = exprs
+        .iter()
         .map(|v| compile(ctx, v))
         .collect::<Result<Vec<_>, _>>()?;
 

--- a/src/ketos/string.rs
+++ b/src/ketos/string.rs
@@ -58,7 +58,7 @@ struct StringReader<'a> {
 
 impl<'a> StringReader<'a> {
     fn new(input: &str, pos: BytePos, ty: StringType) -> StringReader {
-        StringReader{
+        StringReader {
             chars: input.char_indices(),
             start: pos,
             last_index: 0,
@@ -68,45 +68,68 @@ impl<'a> StringReader<'a> {
     }
 
     fn parse_byte(&mut self) -> Result<(u8, usize), ParseError> {
-        self.expect('#', |slf, ch| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidChar(ch)))?;
-        self.expect('b', |slf, ch| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidChar(ch)))?;
-        self.expect('\'', |slf, ch| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidChar(ch)))?;
+        self.expect('#', |slf, ch| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+        })?;
+        self.expect('b', |slf, ch| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+        })?;
+        self.expect('\'', |slf, ch| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+        })?;
 
         let ch = match self.consume_char()? {
-            '\'' => return Err(ParseError::new(self.span_one(),
-                ParseErrorKind::InvalidChar('\''))),
+            '\'' => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidChar('\''),
+                ))
+            }
             '\\' => self.parse_byte_escape()?,
             ch if ch.is_ascii() => ch as u8,
-            ch => return Err(ParseError::new(self.span_one(),
-                ParseErrorKind::InvalidByte(ch)))
+            ch => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidByte(ch),
+                ))
+            }
         };
 
-        self.expect('\'', |slf, _| ParseError::new(
-            slf.span_from(slf.start, 1),
-            ParseErrorKind::UnterminatedChar))?;
+        self.expect('\'', |slf, _| {
+            ParseError::new(
+                slf.span_from(slf.start, 1),
+                ParseErrorKind::UnterminatedChar,
+            )
+        })?;
 
         Ok((ch, self.last_index + 1))
     }
 
     fn parse_char(&mut self) -> Result<(char, usize), ParseError> {
-        self.expect('#', |slf, ch| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidChar(ch)))?;
-        self.expect('\'', |slf, ch| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidChar(ch)))?;
+        self.expect('#', |slf, ch| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+        })?;
+        self.expect('\'', |slf, ch| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+        })?;
 
         let ch = match self.consume_char()? {
-            '\'' => return Err(ParseError::new(self.span_one(),
-                ParseErrorKind::InvalidChar('\''))),
+            '\'' => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidChar('\''),
+                ))
+            }
             '\\' => self.parse_char_escape()?,
-            ch => ch
+            ch => ch,
         };
 
-        self.expect('\'', |slf, _| ParseError::new(
-            slf.span_from(slf.start, 1),
-            ParseErrorKind::UnterminatedChar))?;
+        self.expect('\'', |slf, _| {
+            ParseError::new(
+                slf.span_from(slf.start, 1),
+                ParseErrorKind::UnterminatedChar,
+            )
+        })?;
 
         Ok((ch, self.last_index + 1))
     }
@@ -118,8 +141,9 @@ impl<'a> StringReader<'a> {
         if self.ty == StringType::Raw {
             n_hash = self.parse_raw_prefix()?;
         } else {
-            self.expect('"', |slf, ch| ParseError::new(slf.span_one(),
-                ParseErrorKind::InvalidChar(ch)))?;
+            self.expect('"', |slf, ch| {
+                ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+            })?;
         }
 
         loop {
@@ -139,8 +163,12 @@ impl<'a> StringReader<'a> {
                 ch if ch.is_ascii() => {
                     res.push(ch as u8);
                 }
-                ch => return Err(ParseError::new(self.span_one(),
-                    ParseErrorKind::InvalidByte(ch)))
+                ch => {
+                    return Err(ParseError::new(
+                        self.span_one(),
+                        ParseErrorKind::InvalidByte(ch),
+                    ))
+                }
             }
         }
 
@@ -155,8 +183,9 @@ impl<'a> StringReader<'a> {
         if self.ty == StringType::Raw {
             n_hash = self.parse_raw_prefix()?;
         } else {
-            self.expect('"', |slf, ch| ParseError::new(slf.span_one(),
-                ParseErrorKind::InvalidChar(ch)))?;
+            self.expect('"', |slf, ch| {
+                ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+            })?;
         }
 
         loop {
@@ -173,7 +202,7 @@ impl<'a> StringReader<'a> {
                         res.push(ch);
                     }
                 }
-                ch => res.push(ch)
+                ch => res.push(ch),
             }
         }
 
@@ -183,15 +212,20 @@ impl<'a> StringReader<'a> {
     fn parse_raw_prefix(&mut self) -> Result<usize, ParseError> {
         let mut n_hash = 0;
 
-        self.expect('r', |slf, ch| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidChar(ch)))?;
+        self.expect('r', |slf, ch| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidChar(ch))
+        })?;
 
         loop {
             match self.consume_char()? {
                 '#' => n_hash += 1,
                 '"' => break,
-                ch => return Err(ParseError::new(self.span_one(),
-                    ParseErrorKind::InvalidChar(ch)))
+                ch => {
+                    return Err(ParseError::new(
+                        self.span_one(),
+                        ParseErrorKind::InvalidChar(ch),
+                    ))
+                }
             }
         }
 
@@ -227,7 +261,8 @@ impl<'a> StringReader<'a> {
                     }
                     _ => Err(ParseError::new(
                         self.span_from(ind as BytePos, 1),
-                        ParseErrorKind::InvalidChar('\r')))
+                        ParseErrorKind::InvalidChar('\r'),
+                    )),
                 }
             }
             Some((ind, ch)) => {
@@ -235,17 +270,21 @@ impl<'a> StringReader<'a> {
                 self.end_index = ind + ch.len_utf8();
                 Ok(ch)
             }
-            None => Err(ParseError::new(self.span_from(self.start, 1),
+            None => Err(ParseError::new(
+                self.span_from(self.start, 1),
                 if self.ty == StringType::Single {
                     ParseErrorKind::UnterminatedChar
                 } else {
                     ParseErrorKind::UnterminatedString
-                }))
+                },
+            )),
         }
     }
 
     fn expect<F>(&mut self, ch: char, f: F) -> Result<(), ParseError>
-            where F: FnOnce(&Self, char) -> ParseError {
+    where
+        F: FnOnce(&Self, char) -> ParseError,
+    {
         let c = self.consume_char()?;
         if c == ch {
             Ok(())
@@ -263,11 +302,15 @@ impl<'a> StringReader<'a> {
             'n' => Ok(b'\n'),
             'r' => Ok(b'\r'),
             't' => Ok(b'\t'),
-            'u' => Err(ParseError::new(self.span_one(),
-                ParseErrorKind::InvalidByteEscape('u'))),
+            'u' => Err(ParseError::new(
+                self.span_one(),
+                ParseErrorKind::InvalidByteEscape('u'),
+            )),
             'x' => self.parse_hex_byte_escape(),
-            ch => Err(ParseError::new(self.span_one(),
-                ParseErrorKind::UnknownCharEscape(ch)))
+            ch => Err(ParseError::new(
+                self.span_one(),
+                ParseErrorKind::UnknownCharEscape(ch),
+            )),
         }
     }
 
@@ -282,8 +325,10 @@ impl<'a> StringReader<'a> {
             't' => Ok('\t'),
             'u' => self.parse_unicode(),
             'x' => self.parse_hex_char_escape(),
-            ch => Err(ParseError::new(self.span_one(),
-                ParseErrorKind::UnknownCharEscape(ch)))
+            ch => Err(ParseError::new(
+                self.span_one(),
+                ParseErrorKind::UnknownCharEscape(ch),
+            )),
         }
     }
 
@@ -293,13 +338,15 @@ impl<'a> StringReader<'a> {
                 self.consume_char()?;
                 loop {
                     match self.peek_char()? {
-                        ' ' | '\t' => { self.consume_char()?; },
-                        _ => break
+                        ' ' | '\t' => {
+                            self.consume_char()?;
+                        }
+                        _ => break,
                     }
                 }
                 Ok(None)
             }
-            _ => self.parse_byte_escape().map(Some)
+            _ => self.parse_byte_escape().map(Some),
         }
     }
 
@@ -309,26 +356,36 @@ impl<'a> StringReader<'a> {
                 self.consume_char()?;
                 loop {
                     match self.peek_char()? {
-                        ' ' | '\t' => { self.consume_char()?; },
-                        _ => break
+                        ' ' | '\t' => {
+                            self.consume_char()?;
+                        }
+                        _ => break,
                     }
                 }
                 Ok(None)
             }
-            _ => self.parse_char_escape().map(Some)
+            _ => self.parse_char_escape().map(Some),
         }
     }
 
     fn parse_hex_byte_escape(&mut self) -> Result<u8, ParseError> {
         let a = match self.consume_char()? {
-            ch if !ch.is_digit(16) => return Err(ParseError::new(
-                self.span_one(), ParseErrorKind::InvalidNumericEscape('x'))),
-            ch => ch
+            ch if !ch.is_digit(16) => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidNumericEscape('x'),
+                ))
+            }
+            ch => ch,
         };
         let b = match self.consume_char()? {
-            ch if !ch.is_digit(16) => return Err(ParseError::new(
-                self.span_one(), ParseErrorKind::InvalidNumericEscape('x'))),
-            ch => ch
+            ch if !ch.is_digit(16) => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidNumericEscape('x'),
+                ))
+            }
+            ch => ch,
         };
 
         Ok(((a.to_digit(16).unwrap() << 4) | b.to_digit(16).unwrap()) as u8)
@@ -336,27 +393,38 @@ impl<'a> StringReader<'a> {
 
     fn parse_hex_char_escape(&mut self) -> Result<char, ParseError> {
         let a = match self.consume_char()? {
-            ch if !ch.is_digit(16) => return Err(ParseError::new(
-                self.span_one(), ParseErrorKind::InvalidNumericEscape('x'))),
-            ch => ch
+            ch if !ch.is_digit(16) => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidNumericEscape('x'),
+                ))
+            }
+            ch => ch,
         };
         let b = match self.consume_char()? {
-            ch if !ch.is_digit(16) => return Err(ParseError::new(
-                self.span_one(), ParseErrorKind::InvalidNumericEscape('x'))),
-            ch => ch
+            ch if !ch.is_digit(16) => {
+                return Err(ParseError::new(
+                    self.span_one(),
+                    ParseErrorKind::InvalidNumericEscape('x'),
+                ))
+            }
+            ch => ch,
         };
 
         if a > '7' {
-            return Err(ParseError::new(self.back_span(1, 2),
-                ParseErrorKind::InvalidNumericEscape('x')));
+            return Err(ParseError::new(
+                self.back_span(1, 2),
+                ParseErrorKind::InvalidNumericEscape('x'),
+            ));
         }
 
         Ok(((a.to_digit(16).unwrap() << 4) | b.to_digit(16).unwrap()) as u8 as char)
     }
 
     fn parse_unicode(&mut self) -> Result<char, ParseError> {
-        self.expect('{', |slf, _| ParseError::new(slf.span_one(),
-            ParseErrorKind::InvalidNumericEscape('u')))?;
+        self.expect('{', |slf, _| {
+            ParseError::new(slf.span_one(), ParseErrorKind::InvalidNumericEscape('u'))
+        })?;
 
         let mut n_digits = 0;
         let mut n_pad = 0;
@@ -364,60 +432,78 @@ impl<'a> StringReader<'a> {
 
         loop {
             match self.consume_char()? {
-                '_' => { n_pad += 1; }
+                '_' => {
+                    n_pad += 1;
+                }
                 '}' if n_digits != 0 => break,
                 ch if ch.is_digit(16) => {
                     if n_digits == 6 {
-                        return Err(ParseError::new(self.span_one(),
-                            ParseErrorKind::InvalidNumericEscape(ch)));
+                        return Err(ParseError::new(
+                            self.span_one(),
+                            ParseErrorKind::InvalidNumericEscape(ch),
+                        ));
                     }
                     n_digits += 1;
                     total = (total << 4) | ch.to_digit(16).unwrap();
                 }
-                ch => return Err(ParseError::new(
-                    self.span_one(), ParseErrorKind::InvalidNumericEscape(ch))),
+                ch => {
+                    return Err(ParseError::new(
+                        self.span_one(),
+                        ParseErrorKind::InvalidNumericEscape(ch),
+                    ))
+                }
             }
         }
 
-        ::std::char::from_u32(total)
-            .ok_or_else(|| ParseError::new(
+        ::std::char::from_u32(total).ok_or_else(|| {
+            ParseError::new(
                 self.back_span(n_digits + n_pad, n_digits + n_pad),
-                ParseErrorKind::InvalidNumericEscape('u')))
+                ParseErrorKind::InvalidNumericEscape('u'),
+            )
+        })
     }
 
     fn peek_char(&mut self) -> Result<char, ParseError> {
         match self.chars.clone().next() {
             Some((_, ch)) => Ok(ch),
-            None => Err(ParseError::new(self.span_from(self.start, 1),
+            None => Err(ParseError::new(
+                self.span_from(self.start, 1),
                 if self.ty == StringType::Single {
                     ParseErrorKind::UnterminatedChar
                 } else {
                     ParseErrorKind::UnterminatedString
-                }))
+                },
+            )),
         }
     }
 
     fn back_span(&self, back: BytePos, len: BytePos) -> Span {
         let start = self.start + self.last_index as BytePos - back;
-        Span{lo: start, hi: start + len}
+        Span {
+            lo: start,
+            hi: start + len,
+        }
     }
 
     fn span_one(&self) -> Span {
-        Span{
+        Span {
             lo: self.start + self.last_index as BytePos,
             hi: self.start + self.end_index as BytePos,
         }
     }
 
     fn span_from(&self, start: BytePos, len: BytePos) -> Span {
-        Span{lo: start, hi: start + len}
+        Span {
+            lo: start,
+            hi: start + len,
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use parser::ParseError;
     use super::{StringReader, StringType};
+    use parser::ParseError;
 
     fn parse_bytes(s: &str) -> Result<Vec<u8>, ParseError> {
         let mut r = StringReader::new(s, 0, StringType::Normal);

--- a/src/ketos/trace.rs
+++ b/src/ketos/trace.rs
@@ -24,7 +24,7 @@ pub struct Trace {
 impl Trace {
     /// Creates a new `Trace` from a series of items.
     pub fn new(items: Vec<TraceItem>, expr: Option<Value>) -> Trace {
-        Trace{
+        Trace {
             items: items,
             expr: expr,
         }
@@ -111,30 +111,24 @@ impl NameDisplay for Trace {
 
         for item in &self.items {
             match *item {
-                CallCode(m, n) => writeln!(f,
-                    "  In {}, function {}", names.get(m), names.get(n))?,
-                CallExpr(m) => writeln!(f,
-                    "  In {}, call expression", names.get(m))?,
-                CallLambda(m) => writeln!(f,
-                    "  In {}, lambda", names.get(m))?,
-                CallMacro(m, n) => writeln!(f,
-                    "  In {}, macro expansion {}", names.get(m), names.get(n))?,
-                CallOperator(m, n) => writeln!(f,
-                    "  In {}, operator {}", names.get(m), names.get(n))?,
-                CallSys(n) => writeln!(f,
-                    "  In system function {}", names.get(n))?,
-                Define(m, n) => writeln!(f,
-                    "  In {}, define {}", names.get(m), names.get(n))?,
-                DefineConst(m, n) => writeln!(f,
-                    "  In {}, const {}", names.get(m), names.get(n))?,
-                DefineLambda(m) => writeln!(f,
-                    "  In {}, lambda", names.get(m))?,
-                DefineMacro(m, n) => writeln!(f,
-                    "  In {}, macro {}", names.get(m), names.get(n))?,
-                DefineStruct(m, n) => writeln!(f,
-                    "  In {}, struct {}", names.get(m), names.get(n))?,
-                UseModule(m, n) => writeln!(f,
-                    "  In {}, use {}", names.get(m), names.get(n))?,
+                CallCode(m, n) => writeln!(f, "  In {}, function {}", names.get(m), names.get(n))?,
+                CallExpr(m) => writeln!(f, "  In {}, call expression", names.get(m))?,
+                CallLambda(m) => writeln!(f, "  In {}, lambda", names.get(m))?,
+                CallMacro(m, n) => {
+                    writeln!(f, "  In {}, macro expansion {}", names.get(m), names.get(n))?
+                }
+                CallOperator(m, n) => {
+                    writeln!(f, "  In {}, operator {}", names.get(m), names.get(n))?
+                }
+                CallSys(n) => writeln!(f, "  In system function {}", names.get(n))?,
+                Define(m, n) => writeln!(f, "  In {}, define {}", names.get(m), names.get(n))?,
+                DefineConst(m, n) => writeln!(f, "  In {}, const {}", names.get(m), names.get(n))?,
+                DefineLambda(m) => writeln!(f, "  In {}, lambda", names.get(m))?,
+                DefineMacro(m, n) => writeln!(f, "  In {}, macro {}", names.get(m), names.get(n))?,
+                DefineStruct(m, n) => {
+                    writeln!(f, "  In {}, struct {}", names.get(m), names.get(n))?
+                }
+                UseModule(m, n) => writeln!(f, "  In {}, use {}", names.get(m), names.get(n))?,
             }
         }
 

--- a/src/ketos/value.rs
+++ b/src/ketos/value.rs
@@ -77,11 +77,10 @@ impl Value {
 
     /// Returns a value containing a foreign function.
     pub fn new_foreign_fn<F>(name: Name, f: F) -> Value
-            where F: AnyValue + Fn(&Context, &mut [Value]) -> Result<Value, Error> {
-        Value::new_foreign(ForeignFn{
-            name: name,
-            f: f,
-        })
+    where
+        F: AnyValue + Fn(&Context, &mut [Value]) -> Result<Value, Error>,
+    {
+        Value::new_foreign(ForeignFn { name: name, f: f })
     }
 
     /// Compares two values; returns an error if the values cannot be compared.
@@ -89,8 +88,9 @@ impl Value {
         let ord = match (self, rhs) {
             (&Value::Unit, &Value::Unit) => Ordering::Equal,
             (&Value::Bool(a), &Value::Bool(b)) => a.cmp(&b),
-            (&Value::Float(a), &Value::Float(b)) =>
-                a.partial_cmp(&b).ok_or(ExecError::CompareNaN)?,
+            (&Value::Float(a), &Value::Float(b)) => {
+                a.partial_cmp(&b).ok_or(ExecError::CompareNaN)?
+            }
             (&Value::Integer(ref a), &Value::Integer(ref b)) => a.cmp(&b),
             (&Value::Ratio(ref a), &Value::Ratio(ref b)) => a.cmp(&b),
             (&Value::Name(a), &Value::Name(b)) => a.cmp(&b),
@@ -101,13 +101,12 @@ impl Value {
             (&Value::Path(ref a), &Value::Path(ref b)) => a.cmp(&b),
             (&Value::Unit, &Value::List(_)) => Ordering::Less,
             (&Value::List(_), &Value::Unit) => Ordering::Greater,
-            (&Value::List(ref a), &Value::List(ref b)) =>
-                cmp_value_slice(a, b)?,
+            (&Value::List(ref a), &Value::List(ref b)) => cmp_value_slice(a, b)?,
             (&Value::Struct(ref a), &Value::Struct(ref b)) => {
                 if a.def() == b.def() {
                     cmp_value_slice(a.fields(), b.fields())?
                 } else {
-                    return Err(ExecError::StructMismatch{
+                    return Err(ExecError::StructMismatch {
                         lhs: a.def().name(),
                         rhs: b.def().name(),
                     });
@@ -116,20 +115,16 @@ impl Value {
 
             // Coercible numeric comparisons
             (&Value::Float(a), &Value::Integer(ref b)) => {
-                coerce_compare_float(a, true,
-                    b.to_f64(), b.is_positive())?
+                coerce_compare_float(a, true, b.to_f64(), b.is_positive())?
             }
             (&Value::Float(a), &Value::Ratio(ref b)) => {
-                coerce_compare_float(a, true,
-                    b.to_f64(), b.is_positive())?
+                coerce_compare_float(a, true, b.to_f64(), b.is_positive())?
             }
             (&Value::Integer(ref a), &Value::Float(b)) => {
-                coerce_compare_float(b, false,
-                    a.to_f64(), a.is_positive())?
+                coerce_compare_float(b, false, a.to_f64(), a.is_positive())?
             }
             (&Value::Ratio(ref a), &Value::Float(b)) => {
-                coerce_compare_float(b, false,
-                    a.to_f64(), a.is_positive())?
+                coerce_compare_float(b, false, a.to_f64(), a.is_positive())?
             }
             (&Value::Integer(ref a), &Value::Ratio(ref b)) => {
                 let a = Ratio::from_integer(a.clone());
@@ -141,30 +136,38 @@ impl Value {
             }
 
             // Non-comparable types
-            (&Value::StructDef(_), &Value::StructDef(_)) =>
-                return Err(ExecError::CannotCompare("struct-def")),
-            (&Value::Function(_), &Value::Function(_)) =>
-                return Err(ExecError::CannotCompare("function")),
-            (&Value::Lambda(_), &Value::Lambda(_)) =>
-                return Err(ExecError::CannotCompare("lambda")),
-            (&Value::Quote(_, _), &Value::Quote(_, _)) =>
-                return Err(ExecError::CannotCompare("quote")),
-            (&Value::Quasiquote(_, _), &Value::Quasiquote(_, _)) =>
-                return Err(ExecError::CannotCompare("quasiquote")),
-            (&Value::Comma(_, _), &Value::Comma(_, _)) =>
-                return Err(ExecError::CannotCompare("comma")),
-            (&Value::CommaAt(_, _), &Value::CommaAt(_, _)) =>
-                return Err(ExecError::CannotCompare("comma-at")),
+            (&Value::StructDef(_), &Value::StructDef(_)) => {
+                return Err(ExecError::CannotCompare("struct-def"))
+            }
+            (&Value::Function(_), &Value::Function(_)) => {
+                return Err(ExecError::CannotCompare("function"))
+            }
+            (&Value::Lambda(_), &Value::Lambda(_)) => {
+                return Err(ExecError::CannotCompare("lambda"))
+            }
+            (&Value::Quote(_, _), &Value::Quote(_, _)) => {
+                return Err(ExecError::CannotCompare("quote"))
+            }
+            (&Value::Quasiquote(_, _), &Value::Quasiquote(_, _)) => {
+                return Err(ExecError::CannotCompare("quasiquote"))
+            }
+            (&Value::Comma(_, _), &Value::Comma(_, _)) => {
+                return Err(ExecError::CannotCompare("comma"))
+            }
+            (&Value::CommaAt(_, _), &Value::CommaAt(_, _)) => {
+                return Err(ExecError::CannotCompare("comma-at"))
+            }
 
             (&Value::Foreign(ref a), ref b) => a.compare_to_value(b)?,
-            (ref a, &Value::Foreign(ref b)) =>
-                flip_ordering(b.compare_to_value(a)?),
+            (ref a, &Value::Foreign(ref b)) => flip_ordering(b.compare_to_value(a)?),
 
             // Type mismatch
-            (a, b) => return Err(ExecError::TypeMismatch{
-                lhs: a.type_name(),
-                rhs: b.type_name(),
-            })
+            (a, b) => {
+                return Err(ExecError::TypeMismatch {
+                    lhs: a.type_name(),
+                    rhs: b.type_name(),
+                })
+            }
         };
 
         Ok(ord)
@@ -180,18 +183,10 @@ impl Value {
             (&Value::Integer(ref a), &Value::Integer(ref b)) => a == b,
             (&Value::Ratio(ref a), &Value::Ratio(ref b)) => a == b,
 
-            (&Value::Float(a), &Value::Integer(ref b)) => {
-                coerce_equal_float(a, b.to_f64())
-            }
-            (&Value::Float(a), &Value::Ratio(ref b)) => {
-                coerce_equal_float(a, b.to_f64())
-            }
-            (&Value::Integer(ref a), &Value::Float(b)) => {
-                coerce_equal_float(b, a.to_f64())
-            }
-            (&Value::Ratio(ref a), &Value::Float(b)) => {
-                coerce_equal_float(b, a.to_f64())
-            }
+            (&Value::Float(a), &Value::Integer(ref b)) => coerce_equal_float(a, b.to_f64()),
+            (&Value::Float(a), &Value::Ratio(ref b)) => coerce_equal_float(a, b.to_f64()),
+            (&Value::Integer(ref a), &Value::Float(b)) => coerce_equal_float(b, a.to_f64()),
+            (&Value::Ratio(ref a), &Value::Float(b)) => coerce_equal_float(b, a.to_f64()),
 
             (&Value::Integer(ref a), &Value::Ratio(ref b)) => a == b,
             (&Value::Ratio(ref a), &Value::Integer(ref b)) => a == b,
@@ -202,17 +197,15 @@ impl Value {
             (&Value::String(ref a), &Value::String(ref b)) => a == b,
             (&Value::Bytes(ref a), &Value::Bytes(ref b)) => a == b,
             (&Value::Path(ref a), &Value::Path(ref b)) => a == b,
-            (&Value::Quote(ref a, na), &Value::Quote(ref b, nb)) =>
-                na == nb && a.is_equal(&b)?,
+            (&Value::Quote(ref a, na), &Value::Quote(ref b, nb)) => na == nb && a.is_equal(&b)?,
             (&Value::Unit, &Value::List(_)) => false,
             (&Value::List(_), &Value::Unit) => false,
-            (&Value::List(ref a), &Value::List(ref b)) =>
-                eq_value_slice(a, b)?,
+            (&Value::List(ref a), &Value::List(ref b)) => eq_value_slice(a, b)?,
             (&Value::Struct(ref a), &Value::Struct(ref b)) => {
                 if a.def() == b.def() {
                     eq_value_slice(a.fields(), b.fields())?
                 } else {
-                    return Err(ExecError::StructMismatch{
+                    return Err(ExecError::StructMismatch {
                         lhs: a.def().name(),
                         rhs: b.def().name(),
                     });
@@ -225,10 +218,12 @@ impl Value {
             (&Value::Foreign(ref a), ref b) => a.is_equal_to_value(b)?,
             (ref a, &Value::Foreign(ref b)) => b.is_equal_to_value(a)?,
 
-            (a, b) => return Err(ExecError::TypeMismatch{
-                lhs: a.type_name(),
-                rhs: b.type_name(),
-            })
+            (a, b) => {
+                return Err(ExecError::TypeMismatch {
+                    lhs: a.type_name(),
+                    rhs: b.type_name(),
+                })
+            }
         };
 
         Ok(eq)
@@ -245,31 +240,31 @@ impl Value {
             (&Value::Float(a), &Value::Float(b)) => float_is_identical(a, b),
             (&Value::Integer(ref a), &Value::Integer(ref b)) => a == b,
             (&Value::Ratio(ref a), &Value::Ratio(ref b)) => a == b,
-            (&Value::Struct(ref a), &Value::Struct(ref b)) =>
-                a.def() == b.def() &&
-                    a.fields().iter().zip(b.fields().iter())
-                        .all(|(a, b)| a.is_identical(b)),
+            (&Value::Struct(ref a), &Value::Struct(ref b)) => {
+                a.def() == b.def() && a
+                    .fields()
+                    .iter()
+                    .zip(b.fields().iter())
+                    .all(|(a, b)| a.is_identical(b))
+            }
             (&Value::Name(a), &Value::Name(b)) => a == b,
             (&Value::Keyword(a), &Value::Keyword(b)) => a == b,
             (&Value::Char(a), &Value::Char(b)) => a == b,
             (&Value::String(ref a), &Value::String(ref b)) => a == b,
             (&Value::Bytes(ref a), &Value::Bytes(ref b)) => a == b,
             (&Value::Path(ref a), &Value::Path(ref b)) => a == b,
-            (&Value::Quasiquote(ref a, na), &Value::Quasiquote(ref b, nb)) =>
-                na == nb && a.is_identical(b),
-            (&Value::Comma(ref a, na), &Value::Comma(ref b, nb)) =>
-                na == nb && a.is_identical(b),
-            (&Value::Quote(ref a, na), &Value::Quote(ref b, nb)) =>
-                na == nb && a.is_identical(b),
-            (&Value::List(ref a), &Value::List(ref b)) =>
-                list_is_identical(a, b),
+            (&Value::Quasiquote(ref a, na), &Value::Quasiquote(ref b, nb)) => {
+                na == nb && a.is_identical(b)
+            }
+            (&Value::Comma(ref a, na), &Value::Comma(ref b, nb)) => na == nb && a.is_identical(b),
+            (&Value::Quote(ref a, na), &Value::Quote(ref b, nb)) => na == nb && a.is_identical(b),
+            (&Value::List(ref a), &Value::List(ref b)) => list_is_identical(a, b),
             (&Value::Function(ref a), &Value::Function(ref b)) => a == b,
             (&Value::Lambda(ref a), &Value::Lambda(ref b)) => a == b,
 
-            (&Value::Foreign(ref a), &Value::Foreign(ref b)) =>
-                a.is_identical_to(&**b),
+            (&Value::Foreign(ref a), &Value::Foreign(ref b)) => a.is_identical_to(&**b),
 
-            _ => false
+            _ => false,
         }
     }
 
@@ -285,8 +280,9 @@ impl Value {
     /// If `n` would overflow.
     pub fn quasiquote(self, n: u32) -> Value {
         match self {
-            Value::Quasiquote(v, i) => Value::Quasiquote(v,
-                i.checked_add(n).expect("quasiquote overflow")),
+            Value::Quasiquote(v, i) => {
+                Value::Quasiquote(v, i.checked_add(n).expect("quasiquote overflow"))
+            }
             v => Value::Quasiquote(Box::new(v), n),
         }
     }
@@ -302,23 +298,24 @@ impl Value {
                 let denom = r.denom().bits();
                 1 + numer + denom
             }
-            Value::Struct(ref s) =>
-                1 + s.fields().iter().map(|f| f.size()).fold(0, |a, b| a + b),
+            Value::Struct(ref s) => 1 + s.fields().iter().map(|f| f.size()).fold(0, |a, b| a + b),
             Value::StructDef(ref d) => d.def().size(),
             Value::String(ref s) => 1 + s.len(),
             Value::Bytes(ref s) => 1 + s.len(),
             Value::Path(ref p) => 1 + p.as_os_str().len(),
-            Value::Comma(ref v, _) |
-            Value::CommaAt(ref v, _) |
-            Value::Quasiquote(ref v, _) |
-            Value::Quote(ref v, _) => 1 + v.size(),
-            Value::List(ref li) =>
-                1 + li.iter().map(|v| v.size()).fold(0, |a, b| a + b),
-            Value::Lambda(ref l) =>
-                1 + l.values.as_ref().map_or(0,
-                    |v| v.iter().map(|v| v.size()).fold(0, |a, b| a + b)),
+            Value::Comma(ref v, _)
+            | Value::CommaAt(ref v, _)
+            | Value::Quasiquote(ref v, _)
+            | Value::Quote(ref v, _) => 1 + v.size(),
+            Value::List(ref li) => 1 + li.iter().map(|v| v.size()).fold(0, |a, b| a + b),
+            Value::Lambda(ref l) => {
+                1 + l
+                    .values
+                    .as_ref()
+                    .map_or(0, |v| v.iter().map(|v| v.size()).fold(0, |a, b| a + b))
+            }
             Value::Foreign(ref v) => v.size(),
-            _ => 1
+            _ => 1,
         }
     }
 
@@ -329,8 +326,7 @@ impl Value {
     /// If `n` would overflow.
     pub fn comma(self, n: u32) -> Value {
         match self {
-            Value::Comma(v, i) => Value::Comma(v,
-                i.checked_add(n).expect("comma overflow")),
+            Value::Comma(v, i) => Value::Comma(v, i.checked_add(n).expect("comma overflow")),
             Value::CommaAt(v, i) => Value::CommaAt(v, i + n),
             v => Value::Comma(Box::new(v), n),
         }
@@ -343,9 +339,8 @@ impl Value {
     /// If `n` would overflow.
     pub fn comma_at(self, n: u32) -> Value {
         match self {
-            Value::CommaAt(v, i) => Value::CommaAt(v,
-                i.checked_add(n).expect("comma_at overflow")),
-            v => Value::CommaAt(Box::new(v), n)
+            Value::CommaAt(v, i) => Value::CommaAt(v, i.checked_add(n).expect("comma_at overflow")),
+            v => Value::CommaAt(Box::new(v), n),
         }
     }
 
@@ -356,8 +351,7 @@ impl Value {
     /// If `n` would overflow.
     pub fn quote(self, n: u32) -> Value {
         match self {
-            Value::Quote(v, i) => Value::Quote(v,
-                i.checked_add(n).expect("quote overflow")),
+            Value::Quote(v, i) => Value::Quote(v, i.checked_add(n).expect("quote overflow")),
             v => Value::Quote(Box::new(v), n),
         }
     }
@@ -378,10 +372,10 @@ impl Value {
             Value::Name(_) => "name",
             Value::Keyword(_) => "keyword",
             // XXX: Does this make sense?
-            Value::Quasiquote(_, _) |
-            Value::Comma(_, _) |
-            Value::CommaAt(_, _) |
-            Value::Quote(_, _) => "object",
+            Value::Quasiquote(_, _)
+            | Value::Comma(_, _)
+            | Value::CommaAt(_, _)
+            | Value::Quote(_, _) => "object",
             Value::List(_) => "list",
             Value::Struct(_) => "struct",
             Value::StructDef(_) => "struct-def",
@@ -412,7 +406,7 @@ pub trait ForeignValue: AnyValue + fmt::Debug {
     fn compare_to_value(&self, rhs: &Value) -> Result<Ordering, ExecError> {
         match *rhs {
             Value::Foreign(ref rhs) => self.compare_to(&**rhs),
-            ref v => Err(ExecError::expected(self.type_name(), v))
+            ref v => Err(ExecError::expected(self.type_name(), v)),
         }
     }
 
@@ -431,7 +425,7 @@ pub trait ForeignValue: AnyValue + fmt::Debug {
     ///
     /// The default implementation unconditionally returns an error.
     fn is_equal_to(&self, rhs: &ForeignValue) -> Result<bool, ExecError> {
-        Err(ExecError::TypeMismatch{
+        Err(ExecError::TypeMismatch {
             lhs: self.type_name(),
             rhs: rhs.type_name(),
         })
@@ -444,7 +438,7 @@ pub trait ForeignValue: AnyValue + fmt::Debug {
     fn is_equal_to_value(&self, rhs: &Value) -> Result<bool, ExecError> {
         match *rhs {
             Value::Foreign(ref rhs) => self.is_equal_to(&**rhs),
-            ref v => Err(ExecError::expected(self.type_name(), v))
+            ref v => Err(ExecError::expected(self.type_name(), v)),
         }
     }
 
@@ -475,9 +469,8 @@ pub trait ForeignValue: AnyValue + fmt::Debug {
     /// Calls the value as a function.
     ///
     /// The default implementation unconditionally returns an error.
-    fn call_value(&self, ctx: &Context, args: &mut [Value])
-            -> Result<Value, Error> {
-        Err(From::from(ExecError::TypeError{
+    fn call_value(&self, ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
+        Err(From::from(ExecError::TypeError {
             expected: "function",
             found: self.type_name(),
             value: None,
@@ -488,7 +481,9 @@ pub trait ForeignValue: AnyValue + fmt::Debug {
     ///
     /// The result will be used in applying memory restrictions to executing code.
     /// The result **MUST NOT** change for the lifetime of the value.
-    fn size(&self) -> usize { 2 }
+    fn size(&self) -> usize {
+        2
+    }
 }
 
 impl_any_cast!{ ForeignValue }
@@ -506,7 +501,9 @@ impl<F> fmt::Debug for ForeignFn<F> {
 }
 
 impl<F> ForeignValue for ForeignFn<F>
-        where F: AnyValue + Fn(&Context, &mut [Value]) -> Result<Value, Error> {
+where
+    F: AnyValue + Fn(&Context, &mut [Value]) -> Result<Value, Error>,
+{
     fn compare_to(&self, _rhs: &ForeignValue) -> Result<Ordering, ExecError> {
         Err(ExecError::CannotCompare("foreign-fn"))
     }
@@ -515,7 +512,9 @@ impl<F> ForeignValue for ForeignFn<F>
         write!(f, "<foreign-fn {}>", names.get(self.name))
     }
 
-    fn type_name(&self) -> &'static str { "foreign-fn" }
+    fn type_name(&self) -> &'static str {
+        "foreign-fn"
+    }
 
     fn call_value(&self, ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         (self.f)(ctx, args)
@@ -585,7 +584,7 @@ impl NameDebug for Value {
                         b'\\' => f.write_str(r"\\")?,
                         b'"' => f.write_str("\\\"")?,
                         b if is_printable(b) => write!(f, "{}", b as char)?,
-                        b => write!(f, "\\x{:02x}", b)?
+                        b => write!(f, "\\x{:02x}", b)?,
                     }
                 }
 
@@ -595,20 +594,28 @@ impl NameDebug for Value {
             Value::Name(name) => write!(f, "{}", names.get(name)),
             Value::Keyword(name) => write!(f, ":{}", names.get(name)),
             Value::Quasiquote(ref v, depth) => {
-                for _ in 0..depth { write!(f, "`")?; }
+                for _ in 0..depth {
+                    write!(f, "`")?;
+                }
                 NameDebug::fmt(v, names, f)
             }
             Value::Comma(ref v, depth) => {
-                for _ in 0..depth { write!(f, ",")?; }
+                for _ in 0..depth {
+                    write!(f, ",")?;
+                }
                 NameDebug::fmt(v, names, f)
             }
             Value::CommaAt(ref v, depth) => {
-                for _ in 0..depth { write!(f, ",")?; }
+                for _ in 0..depth {
+                    write!(f, ",")?;
+                }
                 write!(f, "@")?;
                 NameDebug::fmt(v, names, f)
             }
             Value::Quote(ref v, depth) => {
-                for _ in 0..depth { write!(f, "'")?; }
+                for _ in 0..depth {
+                    write!(f, "'")?;
+                }
                 NameDebug::fmt(v, names, f)
             }
             Value::List(ref l) => {
@@ -637,8 +644,7 @@ impl NameDebug for Value {
 
                     write!(f, "{} {{ ", names.get(def.name()))?;
 
-                    let mut iter = def.def().field_names().into_iter()
-                        .zip(s.fields().iter());
+                    let mut iter = def.def().field_names().into_iter().zip(s.fields().iter());
 
                     if let Some((name, value)) = iter.next() {
                         write!(f, "{}: ", names.get(name))?;
@@ -672,8 +678,7 @@ impl NameDebug for Value {
                     write!(f, "<struct-def {}>", names.get(def.name()))
                 }
             }
-            Value::Function(ref fun) =>
-                write!(f, "<function {}>", names.get(fun.name)),
+            Value::Function(ref fun) => write!(f, "<function {}>", names.get(fun.name)),
             Value::Lambda(ref c) => match c.code.name {
                 Some(name) => write!(f, "<lambda {}>", names.get(name)),
                 None => write!(f, "<lambda>"),
@@ -696,10 +701,22 @@ impl NameDisplay for Value {
     }
 }
 
-fn coerce_compare_float(f: f64, is_lhs: bool, other: Option<f64>, is_pos: bool)
-        -> Result<Ordering, ExecError> {
-    let lt = if is_lhs { Ordering::Less } else { Ordering::Greater };
-    let gt = if is_lhs { Ordering::Greater } else { Ordering::Less };
+fn coerce_compare_float(
+    f: f64,
+    is_lhs: bool,
+    other: Option<f64>,
+    is_pos: bool,
+) -> Result<Ordering, ExecError> {
+    let lt = if is_lhs {
+        Ordering::Less
+    } else {
+        Ordering::Greater
+    };
+    let gt = if is_lhs {
+        Ordering::Greater
+    } else {
+        Ordering::Less
+    };
 
     let ord = match f {
         f if f == INFINITY => gt,
@@ -715,8 +732,8 @@ fn coerce_compare_float(f: f64, is_lhs: bool, other: Option<f64>, is_pos: bool)
                 }
             }
             None if is_pos => lt,
-            None => gt
-        }
+            None => gt,
+        },
     };
 
     Ok(ord)
@@ -793,8 +810,7 @@ fn float_is_identical(a: f64, b: f64) -> bool {
 }
 
 fn list_is_identical(a: &[Value], b: &[Value]) -> bool {
-    a.len() == b.len() &&
-        a.iter().zip(b.iter()).all(|(a, b)| a.is_identical(b))
+    a.len() == b.len() && a.iter().zip(b.iter()).all(|(a, b)| a.is_identical(b))
 }
 
 /// Borrows a Rust value from a `Value`
@@ -809,11 +825,11 @@ macro_rules! simple_from_ref {
             fn from_value_ref(v: &'a Value) -> Result<$ty, ExecError> {
                 match *v {
                     $pat => Ok($expr),
-                    ref v => Err(ExecError::expected($ty_name, v))
+                    ref v => Err(ExecError::expected($ty_name, v)),
                 }
             }
         }
-    }
+    };
 }
 
 macro_rules! integer_from_ref {
@@ -822,11 +838,11 @@ macro_rules! integer_from_ref {
             fn from_value_ref(v: &'a Value) -> Result<$ty, ExecError> {
                 match *v {
                     Value::Integer(ref i) => i.$meth().ok_or(ExecError::Overflow),
-                    ref v => Err(ExecError::expected("integer", v))
+                    ref v => Err(ExecError::expected("integer", v)),
                 }
             }
         }
-    }
+    };
 }
 
 simple_from_ref!{ (); Value::Unit => (); "unit" }
@@ -850,7 +866,7 @@ impl<'a> FromValueRef<'a> for &'a str {
     fn from_value_ref(v: &'a Value) -> Result<&'a str, ExecError> {
         match *v {
             Value::String(ref s) => Ok(s),
-            ref v => Err(ExecError::expected("string", v))
+            ref v => Err(ExecError::expected("string", v)),
         }
     }
 }
@@ -860,7 +876,7 @@ impl<'a> FromValueRef<'a> for &'a Path {
         match *v {
             Value::String(ref s) => Ok(s.as_ref()),
             Value::Path(ref p) => Ok(p),
-            ref v => Err(ExecError::expected("path", v))
+            ref v => Err(ExecError::expected("path", v)),
         }
     }
 }
@@ -870,7 +886,7 @@ impl<'a> FromValueRef<'a> for &'a OsStr {
         match *v {
             Value::String(ref s) => Ok(s.as_ref()),
             Value::Path(ref p) => Ok(p.as_ref()),
-            ref v => Err(ExecError::expected("path", v))
+            ref v => Err(ExecError::expected("path", v)),
         }
     }
 }
@@ -879,7 +895,7 @@ impl<'a> FromValueRef<'a> for &'a Integer {
     fn from_value_ref(v: &'a Value) -> Result<&'a Integer, ExecError> {
         match *v {
             Value::Integer(ref i) => Ok(i),
-            ref v => Err(ExecError::expected("integer", v))
+            ref v => Err(ExecError::expected("integer", v)),
         }
     }
 }
@@ -888,7 +904,7 @@ impl<'a> FromValueRef<'a> for &'a Ratio {
     fn from_value_ref(v: &'a Value) -> Result<&'a Ratio, ExecError> {
         match *v {
             Value::Ratio(ref r) => Ok(r),
-            ref v => Err(ExecError::expected("ratio", v))
+            ref v => Err(ExecError::expected("ratio", v)),
         }
     }
 }
@@ -898,7 +914,7 @@ impl<'a> FromValueRef<'a> for &'a [Value] {
         match *v {
             Value::Unit => Ok(&[]),
             Value::List(ref li) => Ok(li),
-            ref v => Err(ExecError::expected("list", v))
+            ref v => Err(ExecError::expected("list", v)),
         }
     }
 }
@@ -907,7 +923,7 @@ impl<'a> FromValueRef<'a> for &'a Bytes {
     fn from_value_ref(v: &'a Value) -> Result<&'a Bytes, ExecError> {
         match *v {
             Value::Bytes(ref b) => Ok(b),
-            ref v => Err(ExecError::expected("bytes", v))
+            ref v => Err(ExecError::expected("bytes", v)),
         }
     }
 }
@@ -916,7 +932,7 @@ impl<'a> FromValueRef<'a> for &'a [u8] {
     fn from_value_ref(v: &'a Value) -> Result<&'a [u8], ExecError> {
         match *v {
             Value::Bytes(ref b) => Ok(b.as_ref()),
-            ref v => Err(ExecError::expected("bytes", v))
+            ref v => Err(ExecError::expected("bytes", v)),
         }
     }
 }
@@ -925,9 +941,8 @@ impl<'a, T: FromValueRef<'a>> FromValueRef<'a> for Vec<T> {
     fn from_value_ref(v: &'a Value) -> Result<Vec<T>, ExecError> {
         match *v {
             Value::Unit => Ok(Vec::new()),
-            Value::List(ref li) => li.iter()
-                .map(|v| T::from_value_ref(v)).collect(),
-            ref v => Err(ExecError::expected("list", v))
+            Value::List(ref li) => li.iter().map(|v| T::from_value_ref(v)).collect(),
+            ref v => Err(ExecError::expected("list", v)),
         }
     }
 }
@@ -936,7 +951,7 @@ impl<'a> FromValueRef<'a> for &'a Lambda {
     fn from_value_ref(v: &'a Value) -> Result<&'a Lambda, ExecError> {
         match *v {
             Value::Lambda(ref l) => Ok(l),
-            ref v => Err(ExecError::expected("lambda", v))
+            ref v => Err(ExecError::expected("lambda", v)),
         }
     }
 }
@@ -960,11 +975,11 @@ macro_rules! simple_from_value {
             fn from_value(v: Value) -> Result<$ty, ExecError> {
                 match v {
                     $pat => Ok($expr),
-                    ref v => Err(ExecError::expected($ty_name, v))
+                    ref v => Err(ExecError::expected($ty_name, v)),
                 }
             }
         }
-    }
+    };
 }
 
 macro_rules! integer_from_value {
@@ -973,11 +988,11 @@ macro_rules! integer_from_value {
             fn from_value(v: Value) -> Result<$ty, ExecError> {
                 match v {
                     Value::Integer(ref i) => i.$meth().ok_or(ExecError::Overflow),
-                    ref v => Err(ExecError::expected("integer", v))
+                    ref v => Err(ExecError::expected("integer", v)),
                 }
             }
         }
-    }
+    };
 }
 
 simple_from_value!{ (); "unit"; Value::Unit => () }
@@ -1006,7 +1021,7 @@ impl FromValue for PathBuf {
         match v {
             Value::String(s) => Ok(PathBuf::from(s.into_string())),
             Value::Path(p) => Ok(p),
-            ref v => Err(ExecError::expected("path", v))
+            ref v => Err(ExecError::expected("path", v)),
         }
     }
 }
@@ -1028,7 +1043,7 @@ impl FromValue for Lambda {
     fn from_value(v: Value) -> Result<Lambda, ExecError> {
         match v {
             Value::Lambda(l) => Ok(l),
-            ref v => Err(ExecError::expected("lambda", v))
+            ref v => Err(ExecError::expected("lambda", v)),
         }
     }
 }
@@ -1037,9 +1052,8 @@ impl<T: FromValue> FromValue for Vec<T> {
     fn from_value(v: Value) -> Result<Vec<T>, ExecError> {
         match v {
             Value::Unit => Ok(Vec::new()),
-            Value::List(li) => li.into_vec().into_iter()
-                .map(T::from_value).collect(),
-            ref v => Err(ExecError::expected("list", v))
+            Value::List(li) => li.into_vec().into_iter().map(T::from_value).collect(),
+            ref v => Err(ExecError::expected("list", v)),
         }
     }
 }
@@ -1051,7 +1065,7 @@ macro_rules! value_from {
                 $expr
             }
         }
-    }
+    };
 }
 
 value_from!{ (); _ => Value::Unit }
@@ -1133,7 +1147,7 @@ macro_rules! from_integer {
                 Value::Integer(Integer::$meth(i))
             }
         }
-    }
+    };
 }
 
 from_integer!{ i8 from_i8 }

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -1,8 +1,8 @@
 extern crate ketos;
 
-use ketos::{Error, Interpreter, Value};
 use ketos::bytecode::opcodes::*;
 use ketos::name::standard_names;
+use ketos::{Error, Interpreter, Value};
 
 fn lambda(s: &str) -> Result<Vec<u8>, Error> {
     let interp = Interpreter::new();
@@ -11,249 +11,290 @@ fn lambda(s: &str) -> Result<Vec<u8>, Error> {
     match interp.scope().get_named_value("test") {
         Some(Value::Lambda(ref l)) => Ok(l.code.code.clone().into_vec()),
         Some(ref v) => panic!("expected lambda; got {}", v.type_name()),
-        None => panic!("missing `test` function")
+        None => panic!("missing `test` function"),
     }
 }
 
 #[test]
 fn test_const() {
-    assert_eq!(lambda("
+    assert_eq!(
+        lambda(
+            "
         (const c (+ 1 2 3))
         (define (test) c)
-        ").unwrap(), [
-            CONST_0,
-            RETURN,
-        ]);
+        "
+        ).unwrap(),
+        [CONST_0, RETURN,]
+    );
 }
 
 #[test]
 fn test_const_if() {
-    assert_eq!(lambda("(define (test a) (if true (+ a) (- a)))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::ADD.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (if true (+ a) (- a)))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::ADD.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test a) (if false (+ a) (- a)))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::SUB.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (if false (+ a) (- a)))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::SUB.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 }
 
 #[test]
 fn test_const_fold() {
-    assert_eq!(lambda("(define (test a) (+ a 0))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::ADD.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (+ a 0))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::ADD.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test a) (+ 0 a))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::ADD.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (+ 0 a))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::ADD.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test a) (- a 0))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::ADD.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (- a 0))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::ADD.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test a) (- 0 a))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::SUB.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (- 0 a))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::SUB.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test a) (// 1 a))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS_ARGS, standard_names::FLOOR_DIV.get() as u8, 1,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (// 1 a))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS_ARGS,
+            standard_names::FLOOR_DIV.get() as u8,
+            1,
+            RETURN,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test a) (// a 1))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SYS, standard_names::FLOOR.get() as u8,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (// a 1))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_SYS,
+            standard_names::FLOOR.get() as u8,
+            RETURN,
+        ]
+    );
 }
 
 #[test]
 fn test_dec() {
-    assert_eq!(lambda("(define (test a) (- a 1))").unwrap(), [
-        LOAD_0,
-        DEC,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (- a 1))").unwrap(),
+        [LOAD_0, DEC, RETURN,]
+    );
 
-    assert_eq!(lambda("
+    assert_eq!(
+        lambda(
+            "
         (const n 1)
         (define (test a) (- a n))
-        ").unwrap(), [
-            LOAD_0,
-            DEC,
-            RETURN,
-        ]);
+        "
+        ).unwrap(),
+        [LOAD_0, DEC, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test a) (+ a -1))").unwrap(), [
-        LOAD_0,
-        DEC,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (+ a -1))").unwrap(),
+        [LOAD_0, DEC, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test a) (+ -1 a))").unwrap(), [
-        LOAD_0,
-        DEC,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (+ -1 a))").unwrap(),
+        [LOAD_0, DEC, RETURN,]
+    );
 }
 
 #[test]
 fn test_inc() {
-    assert_eq!(lambda("(define (test a) (+ a 1))").unwrap(), [
-        LOAD_0,
-        INC,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (+ a 1))").unwrap(),
+        [LOAD_0, INC, RETURN,]
+    );
 
-    assert_eq!(lambda("
+    assert_eq!(
+        lambda(
+            "
         (const n 1)
         (define (test a) (+ a n))
-        ").unwrap(), [
-            LOAD_0,
-            INC,
-            RETURN,
-        ]);
+        "
+        ).unwrap(),
+        [LOAD_0, INC, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test a) (+ 1 a))").unwrap(), [
-        LOAD_0,
-        INC,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (+ 1 a))").unwrap(),
+        [LOAD_0, INC, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test a) (- a -1))").unwrap(), [
-        LOAD_0,
-        INC,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (- a -1))").unwrap(),
+        [LOAD_0, INC, RETURN,]
+    );
 }
 
 #[test]
 fn test_if() {
-    assert_eq!(lambda("(define (test a b c) (if a b c))").unwrap(), [
-        LOAD_0,
-        JUMP_IF_NOT, 5,
-        LOAD_1,
-        RETURN,
-        LOAD_2,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a b c) (if a b c))").unwrap(),
+        [LOAD_0, JUMP_IF_NOT, 5, LOAD_1, RETURN, LOAD_2, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test a b c) (if (not a) b c))").unwrap(), [
-        LOAD_0,
-        JUMP_IF, 5,
-        LOAD_1,
-        RETURN,
-        LOAD_2,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a b c) (if (not a) b c))").unwrap(),
+        [LOAD_0, JUMP_IF, 5, LOAD_1, RETURN, LOAD_2, RETURN,]
+    );
 }
 
 #[test]
 fn test_lambda() {
-    assert_eq!(lambda("(define (test a b) (+ a b))").unwrap(), [
-        LOAD_PUSH_0,
-        LOAD_PUSH_1,
-        CALL_SYS_ARGS, standard_names::ADD.get() as u8, 2,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a b) (+ a b))").unwrap(),
+        [
+            LOAD_PUSH_0,
+            LOAD_PUSH_1,
+            CALL_SYS_ARGS,
+            standard_names::ADD.get() as u8,
+            2,
+            RETURN,
+        ]
+    );
 }
 
 #[test]
 fn test_call_self() {
-    assert_eq!(lambda("(define (test a) (do (test a) ()))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_SELF, 1,
-        UNIT,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (do (test a) ()))").unwrap(),
+        [LOAD_PUSH_0, CALL_SELF, 1, UNIT, RETURN,]
+    );
 
     // Prevents self-call in case one wants to do something tricky.
-    assert_eq!(lambda("(define (test a) (do ((id test) a) ()))").unwrap(), [
-        GET_DEF_PUSH, 0,
-        LOAD_PUSH_0,
-        CALL, 1,
-        UNIT,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (do ((id test) a) ()))").unwrap(),
+        [GET_DEF_PUSH, 0, LOAD_PUSH_0, CALL, 1, UNIT, RETURN,]
+    );
 }
 
 #[test]
 fn test_tail_recursion() {
-    assert_eq!(lambda("(define (test a) (test a))").unwrap(), [
-        LOAD_PUSH_0,
-        TAIL_CALL_SELF, 1,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (test a))").unwrap(),
+        [LOAD_PUSH_0, TAIL_CALL_SELF, 1,]
+    );
 
-    assert_eq!(lambda("(define (test a)
+    assert_eq!(
+        lambda(
+            "(define (test a)
                          (if (something a)
                             (test 1)
-                            (test 2)))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_CONST_0, 1,
-        JUMP_IF_NOT, 8,
-        CONST_PUSH_1,
-        TAIL_CALL_SELF, 1,
-        CONST_PUSH_2,
-        TAIL_CALL_SELF, 1,
-    ]);
+                            (test 2)))"
+        ).unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_CONST_0,
+            1,
+            JUMP_IF_NOT,
+            8,
+            CONST_PUSH_1,
+            TAIL_CALL_SELF,
+            1,
+            CONST_PUSH_2,
+            TAIL_CALL_SELF,
+            1,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test) (and a (test)))").unwrap(), [
-        GET_DEF_0,
-        JUMP_IF_NOT, 5,
-        TAIL_CALL_SELF, 0,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test) (and a (test)))").unwrap(),
+        [GET_DEF_0, JUMP_IF_NOT, 5, TAIL_CALL_SELF, 0, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test) (let ((a 1)) (test)))").unwrap(), [
-        CONST_PUSH_0,
-        TAIL_CALL_SELF, 0,
-    ]);
+    assert_eq!(
+        lambda("(define (test) (let ((a 1)) (test)))").unwrap(),
+        [CONST_PUSH_0, TAIL_CALL_SELF, 0,]
+    );
 }
 
 #[test]
 fn test_tail_recursion_apply() {
-    assert_eq!(lambda("(define (test a) (apply test a))").unwrap(), [
-        LOAD_0,
-        TAIL_APPLY_SELF, 0,
-    ]);
+    assert_eq!(
+        lambda("(define (test a) (apply test a))").unwrap(),
+        [LOAD_0, TAIL_APPLY_SELF, 0,]
+    );
 
-    assert_eq!(lambda("(define (test a)
+    assert_eq!(
+        lambda(
+            "(define (test a)
                          (if (something a)
                             (apply test ())
-                            (apply test ())))").unwrap(), [
-        LOAD_PUSH_0,
-        CALL_CONST_0, 1,
-        JUMP_IF_NOT, 8,
-        UNIT,
-        TAIL_APPLY_SELF, 0,
-        UNIT,
-        TAIL_APPLY_SELF, 0,
-    ]);
+                            (apply test ())))"
+        ).unwrap(),
+        [
+            LOAD_PUSH_0,
+            CALL_CONST_0,
+            1,
+            JUMP_IF_NOT,
+            8,
+            UNIT,
+            TAIL_APPLY_SELF,
+            0,
+            UNIT,
+            TAIL_APPLY_SELF,
+            0,
+        ]
+    );
 
-    assert_eq!(lambda("(define (test) (and a (apply test ())))").unwrap(), [
-        GET_DEF_0,
-        JUMP_IF_NOT, 6,
-        UNIT,
-        TAIL_APPLY_SELF, 0,
-        RETURN,
-    ]);
+    assert_eq!(
+        lambda("(define (test) (and a (apply test ())))").unwrap(),
+        [GET_DEF_0, JUMP_IF_NOT, 6, UNIT, TAIL_APPLY_SELF, 0, RETURN,]
+    );
 
-    assert_eq!(lambda("(define (test) (let ((a 1)) (apply test ())))").unwrap(), [
-        CONST_PUSH_0,
-        UNIT,
-        TAIL_APPLY_SELF, 0,
-    ]);
+    assert_eq!(
+        lambda("(define (test) (let ((a 1)) (apply test ())))").unwrap(),
+        [CONST_PUSH_0, UNIT, TAIL_APPLY_SELF, 0,]
+    );
 }

--- a/tests/conv.rs
+++ b/tests/conv.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate assert_matches;
+#[macro_use]
+extern crate assert_matches;
 
 extern crate ketos;
 
@@ -26,16 +27,33 @@ fn test_from_value() {
     assert_eq!(from::<String>(into("foo")).unwrap(), "foo");
 
     assert_eq!(from::<Vec<i32>>(Value::Unit).unwrap(), vec![]);
-    assert_eq!(from::<Vec<i32>>(into(vec![1, 2, 3])).unwrap(), vec![1, 2, 3]);
+    assert_eq!(
+        from::<Vec<i32>>(into(vec![1, 2, 3])).unwrap(),
+        vec![1, 2, 3]
+    );
 
-    assert_eq!(from::<(String, i32)>(into(("foo", 1))).unwrap(),
-        ("foo".to_owned(), 1));
+    assert_eq!(
+        from::<(String, i32)>(into(("foo", 1))).unwrap(),
+        ("foo".to_owned(), 1)
+    );
 
     assert_eq!(from::<PathBuf>(into("foo")).unwrap(), PathBuf::from("foo"));
-    assert_eq!(from::<PathBuf>(into(Path::new("foo"))).unwrap(), PathBuf::from("foo"));
-    assert_eq!(from::<OsString>(into("foo")).unwrap(), OsString::from("foo"));
-    assert_eq!(from::<OsString>(into(Path::new("foo"))).unwrap(), OsString::from("foo"));
-    assert_eq!(from::<Bytes>(into(Bytes::from("foo"))).unwrap(), Bytes::from("foo"));
+    assert_eq!(
+        from::<PathBuf>(into(Path::new("foo"))).unwrap(),
+        PathBuf::from("foo")
+    );
+    assert_eq!(
+        from::<OsString>(into("foo")).unwrap(),
+        OsString::from("foo")
+    );
+    assert_eq!(
+        from::<OsString>(into(Path::new("foo"))).unwrap(),
+        OsString::from("foo")
+    );
+    assert_eq!(
+        from::<Bytes>(into(Bytes::from("foo"))).unwrap(),
+        Bytes::from("foo")
+    );
 }
 
 #[test]
@@ -43,16 +61,34 @@ fn test_from_value_ref() {
     assert_eq!(from_ref::<()>(&Value::Unit).unwrap(), ());
     assert_eq!(from_ref::<i32>(&into(456)).unwrap(), 456);
     assert_eq!(from_ref::<&str>(&into("foo")).unwrap(), "foo");
-    assert_eq!(from_ref::<Vec<i32>>(&into(vec![1, 2, 3])).unwrap(), vec![1, 2, 3]);
+    assert_eq!(
+        from_ref::<Vec<i32>>(&into(vec![1, 2, 3])).unwrap(),
+        vec![1, 2, 3]
+    );
 
-    assert_eq!(from_ref::<(&str, i32)>(&into(("foo", 1))).unwrap(), ("foo", 1));
+    assert_eq!(
+        from_ref::<(&str, i32)>(&into(("foo", 1))).unwrap(),
+        ("foo", 1)
+    );
 
     assert_eq!(from_ref::<&Path>(&into("foo")).unwrap(), Path::new("foo"));
-    assert_eq!(from_ref::<&Path>(&into(Path::new("foo"))).unwrap(), Path::new("foo"));
+    assert_eq!(
+        from_ref::<&Path>(&into(Path::new("foo"))).unwrap(),
+        Path::new("foo")
+    );
     assert_eq!(from_ref::<&OsStr>(&into("foo")).unwrap(), OsStr::new("foo"));
-    assert_eq!(from_ref::<&OsStr>(&into(Path::new("foo"))).unwrap(), OsStr::new("foo"));
-    assert_eq!(from_ref::<&Bytes>(&into(Bytes::from("foo"))).unwrap(), &Bytes::from("foo"));
-    assert_eq!(from_ref::<&[u8]>(&into(Bytes::from("foo"))).unwrap(), b"foo");
+    assert_eq!(
+        from_ref::<&OsStr>(&into(Path::new("foo"))).unwrap(),
+        OsStr::new("foo")
+    );
+    assert_eq!(
+        from_ref::<&Bytes>(&into(Bytes::from("foo"))).unwrap(),
+        &Bytes::from("foo")
+    );
+    assert_eq!(
+        from_ref::<&[u8]>(&into(Bytes::from("foo"))).unwrap(),
+        b"foo"
+    );
 }
 
 #[test]

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,15 +1,16 @@
-#[macro_use] extern crate assert_matches;
+#[macro_use]
+extern crate assert_matches;
 extern crate ketos;
 
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use ketos::{
-    BuiltinModuleLoader, FileModuleLoader, ModuleLoader,
-    Context, Error, Interpreter, Value, run_code,
-};
 use ketos::encode::{read_bytecode, write_bytecode};
 use ketos::module::ModuleCode;
+use ketos::{
+    run_code, BuiltinModuleLoader, Context, Error, FileModuleLoader, Interpreter, ModuleLoader,
+    Value,
+};
 
 fn new_interpreter() -> Interpreter {
     let mut loader = FileModuleLoader::with_search_paths(vec![PathBuf::from("lib")]);
@@ -23,11 +24,16 @@ fn new_interpreter() -> Interpreter {
 // Runs `F` twice; first, after compiling and executing input;
 // then, after encoding and decoding and loading the resulting ModuleCode.
 fn run<F>(input: &str, mut f: F) -> Result<(), Error>
-        where F: FnMut(&Context) {
+where
+    F: FnMut(&Context),
+{
     let interp = new_interpreter();
 
-    let code: Vec<_> = interp.compile_exprs(input)?
-        .into_iter().map(Rc::new).collect();
+    let code: Vec<_> = interp
+        .compile_exprs(input)?
+        .into_iter()
+        .map(Rc::new)
+        .collect();
 
     for code in &code {
         interp.execute_code(code.clone())?;
@@ -57,13 +63,15 @@ fn run<F>(input: &str, mut f: F) -> Result<(), Error>
 
 #[test]
 fn test_encode() {
-    run(r#"
+    run(
+        r#"
         (const foo 1)
         (define bar 2)
 
         (const b #b"y halo")
         (const p #p"thar")
-        "#, |ctx| {
+        "#,
+        |ctx| {
             assert_matches!(ctx.scope().get_named_constant("foo"),
                 Some(Value::Integer(ref i)) if i.to_u32() == Some(1));
             assert_matches!(ctx.scope().get_named_value("bar"),
@@ -72,12 +80,14 @@ fn test_encode() {
                 Some(Value::Bytes(ref b)) if b == b"y halo");
             assert_matches!(ctx.scope().get_named_constant("p"),
                 Some(Value::Path(ref p)) if p == Path::new("thar"));
-        }).unwrap();
+        },
+    ).unwrap();
 }
 
 #[test]
 fn test_docs() {
-    run(r#"
+    run(
+        r#"
         (const foo
             "foo doc"
             1)
@@ -93,8 +103,10 @@ fn test_docs() {
         (struct struc
             "struc doc"
             ())
-        "#, |ctx| {
-            run_code(ctx,
+        "#,
+        |ctx| {
+            run_code(
+                ctx,
                 r#"
                 (use code (documentation))
                 (use test (assert-eq))
@@ -104,6 +116,8 @@ fn test_docs() {
                 (assert-eq (documentation 'baz) "baz doc")
                 (assert-eq (documentation 'mac) "mac doc")
                 (assert-eq (documentation 'struc) "struc doc")
-                "#).unwrap();
-        }).unwrap();
+                "#,
+            ).unwrap();
+        },
+    ).unwrap();
 }

--- a/tests/foreign.rs
+++ b/tests/foreign.rs
@@ -1,11 +1,14 @@
-#[macro_use] extern crate assert_matches;
+#[macro_use]
+extern crate assert_matches;
 
-#[macro_use] extern crate ketos;
-#[macro_use] extern crate ketos_derive;
+#[macro_use]
+extern crate ketos;
+#[macro_use]
+extern crate ketos_derive;
 
 use std::cmp::Ordering;
 
-use ketos::{Context, ExecError, Error, ForeignValue, Interpreter, Value};
+use ketos::{Context, Error, ExecError, ForeignValue, Interpreter, Value};
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, FromValueRef, IntoValue)]
 pub struct MyType {
@@ -16,24 +19,26 @@ impl ketos::ForeignValue for MyType {
     fn compare_to(&self, rhs: &ForeignValue) -> Result<Ordering, ExecError> {
         match rhs.downcast_ref::<MyType>() {
             Some(rhs) => Ok(self.cmp(rhs)),
-            None => Err(ExecError::TypeMismatch{
+            None => Err(ExecError::TypeMismatch {
                 lhs: self.type_name(),
                 rhs: rhs.type_name(),
-            })
+            }),
         }
     }
 
     fn is_equal_to(&self, rhs: &ForeignValue) -> Result<bool, ExecError> {
         match rhs.downcast_ref::<MyType>() {
             Some(rhs) => Ok(*self == *rhs),
-            None => Err(ExecError::TypeMismatch{
+            None => Err(ExecError::TypeMismatch {
                 lhs: self.type_name(),
                 rhs: rhs.type_name(),
-            })
+            }),
         }
     }
 
-    fn type_name(&self) -> &'static str { "MyType" }
+    fn type_name(&self) -> &'static str {
+        "MyType"
+    }
 }
 
 fn eval(interp: &Interpreter, input: &str) -> Result<String, Error> {
@@ -45,7 +50,9 @@ fn eval(interp: &Interpreter, input: &str) -> Result<String, Error> {
 fn test_foreign_value() {
     let interp = Interpreter::new();
 
-    interp.scope().add_named_value("my-value", MyType{a: 123}.into());
+    interp
+        .scope()
+        .add_named_value("my-value", MyType { a: 123 }.into());
 
     assert_eq!(eval(&interp, "my-value").unwrap(), "MyType { a: 123 }");
     assert_eq!(eval(&interp, "(type-of my-value)").unwrap(), "MyType");
@@ -60,19 +67,21 @@ fn reflect_args(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 fn test_raw_foreign_fn() {
     let interp = Interpreter::new();
 
-    interp.scope().add_value_with_name("reflect-args",
-        |name| Value::new_foreign_fn(name, reflect_args));
+    interp.scope().add_value_with_name("reflect-args", |name| {
+        Value::new_foreign_fn(name, reflect_args)
+    });
 
     assert_eq!(eval(&interp, "(reflect-args 1 2 3)").unwrap(), "(1 2 3)");
 
-    interp.scope().add_value_with_name("closure-args",
-        |name| Value::new_foreign_fn(name, |_scope, args| Ok(args.into())));
+    interp.scope().add_value_with_name("closure-args", |name| {
+        Value::new_foreign_fn(name, |_scope, args| Ok(args.into()))
+    });
 
     assert_eq!(eval(&interp, "(closure-args 3 2 1)").unwrap(), "(3 2 1)");
 }
 
 fn new_my_type(a: i32) -> Result<MyType, Error> {
-    Ok(MyType{a: a})
+    Ok(MyType { a: a })
 }
 
 fn get_value(a: &MyType) -> Result<i32, Error> {
@@ -100,10 +109,15 @@ fn test_foreign_fn() {
     assert_eq!(eval(&interp, "(new-my-type 1)").unwrap(), "MyType { a: 1 }");
     assert_eq!(eval(&interp, "(get-value (new-my-type 2))").unwrap(), "2");
     assert_eq!(eval(&interp, "(add-pairs '(1 2) '(3 4))").unwrap(), "(4 6)");
-    assert_eq!(eval(&interp, r#"(hello "world")"#).unwrap(), r#""Hello, world!""#);
+    assert_eq!(
+        eval(&interp, r#"(hello "world")"#).unwrap(),
+        r#""Hello, world!""#
+    );
 
-    assert_matches!(eval(&interp, "(add-pairs '(1 2 0) '(3 4))").unwrap_err(),
-        Error::ExecError(ExecError::TypeError{..}));
+    assert_matches!(
+        eval(&interp, "(add-pairs '(1 2 0) '(3 4))").unwrap_err(),
+        Error::ExecError(ExecError::TypeError { .. })
+    );
 }
 
 #[test]
@@ -113,13 +127,37 @@ fn test_compare_foreign_value() {
 
     ketos_fn!{ scope => "new-my-type" => fn new_my_type(a: i32) -> MyType }
 
-    assert_eq!(eval(&interp, "(= (new-my-type 1) (new-my-type 1))").unwrap(), "true");
-    assert_eq!(eval(&interp, "(/= (new-my-type 1) (new-my-type 1))").unwrap(), "false");
-    assert_eq!(eval(&interp, "(= (new-my-type 1) (new-my-type 2))").unwrap(), "false");
-    assert_eq!(eval(&interp, "(/= (new-my-type 1) (new-my-type 2))").unwrap(), "true");
+    assert_eq!(
+        eval(&interp, "(= (new-my-type 1) (new-my-type 1))").unwrap(),
+        "true"
+    );
+    assert_eq!(
+        eval(&interp, "(/= (new-my-type 1) (new-my-type 1))").unwrap(),
+        "false"
+    );
+    assert_eq!(
+        eval(&interp, "(= (new-my-type 1) (new-my-type 2))").unwrap(),
+        "false"
+    );
+    assert_eq!(
+        eval(&interp, "(/= (new-my-type 1) (new-my-type 2))").unwrap(),
+        "true"
+    );
 
-    assert_eq!(eval(&interp, "(< (new-my-type 1) (new-my-type 2))").unwrap(), "true");
-    assert_eq!(eval(&interp, "(> (new-my-type 1) (new-my-type 2))").unwrap(), "false");
-    assert_eq!(eval(&interp, "(< (new-my-type 2) (new-my-type 1))").unwrap(), "false");
-    assert_eq!(eval(&interp, "(> (new-my-type 2) (new-my-type 1))").unwrap(), "true");
+    assert_eq!(
+        eval(&interp, "(< (new-my-type 1) (new-my-type 2))").unwrap(),
+        "true"
+    );
+    assert_eq!(
+        eval(&interp, "(> (new-my-type 1) (new-my-type 2))").unwrap(),
+        "false"
+    );
+    assert_eq!(
+        eval(&interp, "(< (new-my-type 2) (new-my-type 1))").unwrap(),
+        "false"
+    );
+    assert_eq!(
+        eval(&interp, "(> (new-my-type 2) (new-my-type 1))").unwrap(),
+        "true"
+    );
 }

--- a/tests/restrict.rs
+++ b/tests/restrict.rs
@@ -1,19 +1,13 @@
-#[macro_use] extern crate assert_matches;
+#[macro_use]
+extern crate assert_matches;
 extern crate ketos;
 
 use std::time::Duration;
 
-use ketos::{
-    Builder,
-    Error,
-    RestrictConfig,
-    RestrictError,
-};
+use ketos::{Builder, Error, RestrictConfig, RestrictError};
 
 fn run(restrict: RestrictConfig, code: &str) -> Result<(), Error> {
-    let interp = Builder::new()
-        .restrict(restrict)
-        .finish();
+    let interp = Builder::new().restrict(restrict).finish();
 
     interp.run_code(code, None)?;
     Ok(())
@@ -22,43 +16,50 @@ fn run(restrict: RestrictConfig, code: &str) -> Result<(), Error> {
 macro_rules! assert_matches_re {
     ( $e:expr , $re:expr ) => {
         assert_matches!($e, Error::RestrictError(e) if e == $re)
-    }
+    };
 }
 
 #[test]
 fn test_restrict_time() {
-    assert_matches_re!(run(
-        RestrictConfig{
-            execution_time: Some(Duration::from_millis(100)),
-            .. RestrictConfig::permissive()
-        },
-        "
+    assert_matches_re!(
+        run(
+            RestrictConfig {
+                execution_time: Some(Duration::from_millis(100)),
+                ..RestrictConfig::permissive()
+            },
+            "
         (define (foo) (foo))
         (foo)
-        ").unwrap_err(),
-        RestrictError::ExecutionTimeExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::ExecutionTimeExceeded
+    );
 }
 
 #[test]
 fn test_restrict_stack() {
-    assert_matches_re!(run(
-        RestrictConfig{
-            call_stack_size: 100,
-            .. RestrictConfig::permissive()
-        },
-        "
+    assert_matches_re!(
+        run(
+            RestrictConfig {
+                call_stack_size: 100,
+                ..RestrictConfig::permissive()
+            },
+            "
         (define (foo) (bar))
         (define (bar) (foo))
         (foo)
-        ").unwrap_err(),
-        RestrictError::CallStackExceeded);
-
-    assert_matches_re!(run(
-        RestrictConfig{
-            value_stack_size: 100,
-            .. RestrictConfig::permissive()
-        },
         "
+        ).unwrap_err(),
+        RestrictError::CallStackExceeded
+    );
+
+    assert_matches_re!(
+        run(
+            RestrictConfig {
+                value_stack_size: 100,
+                ..RestrictConfig::permissive()
+            },
+            "
         (define (foo)
           (let ((a ()) (a ()) (a ()) (a ()) (a ()) (a ()) (a ()) (a ())
                 (a ()) (a ()) (a ()) (a ()) (a ()) (a ()) (a ()) (a ())
@@ -67,19 +68,23 @@ fn test_restrict_stack() {
             (bar)))
         (define (bar) (foo))
         (foo)
-        ").unwrap_err(),
-        RestrictError::ValueStackExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::ValueStackExceeded
+    );
 }
 
 #[test]
 fn test_restrict_namespace() {
-    { // This block is just so text editors can hide this nonsense.
-        assert_matches_re!(run(
-            RestrictConfig{
-                namespace_size: 20,
-                .. RestrictConfig::permissive()
-            },
-            "
+    {
+        // This block is just so text editors can hide this nonsense.
+        assert_matches_re!(
+            run(
+                RestrictConfig {
+                    namespace_size: 20,
+                    ..RestrictConfig::permissive()
+                },
+                "
             (define a-1 ())
             (define a-2 ())
             (define a-3 ())
@@ -101,72 +106,105 @@ fn test_restrict_namespace() {
             (define a-19 ())
             (define a-20 ())
             (define a-21 ())
-            ").unwrap_err(),
-            RestrictError::NamespaceSizeExceeded);
+            "
+            ).unwrap_err(),
+            RestrictError::NamespaceSizeExceeded
+        );
     }
 }
 
 #[test]
 fn test_restrict_memory() {
-    assert_matches_re!(run(
-        RestrictConfig{
-            memory_limit: 100,
-            .. RestrictConfig::permissive()
-        },
-        "
+    assert_matches_re!(
+        run(
+            RestrictConfig {
+                memory_limit: 100,
+                ..RestrictConfig::permissive()
+            },
+            "
         (define (foo a) (foo (list () a)))
         (foo ())
-        ").unwrap_err(),
-        RestrictError::MemoryLimitExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::MemoryLimitExceeded
+    );
 }
 
 #[test]
 fn test_restrict_integer() {
-    let cfg = RestrictConfig{
+    let cfg = RestrictConfig {
         max_integer_size: 100,
-        .. RestrictConfig::permissive()
+        ..RestrictConfig::permissive()
     };
 
-    assert_matches_re!(run(cfg.clone(), "
+    assert_matches_re!(
+        run(
+            cfg.clone(),
+            "
         0x10000000000000000000000000
-        ").unwrap_err(),
-        RestrictError::IntegerLimitExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::IntegerLimitExceeded
+    );
 
-    assert_matches_re!(run(cfg.clone(), "
+    assert_matches_re!(
+        run(
+            cfg.clone(),
+            "
         (^ 2 1_000_000)
-        ").unwrap_err(),
-        RestrictError::IntegerLimitExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::IntegerLimitExceeded
+    );
 
-    assert_matches_re!(run(cfg.clone(), "
+    assert_matches_re!(
+        run(
+            cfg.clone(),
+            "
         (<< 1 1_000_000)
-        ").unwrap_err(),
-        RestrictError::IntegerLimitExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::IntegerLimitExceeded
+    );
 
-    assert_matches_re!(run(cfg.clone(), "
+    assert_matches_re!(
+        run(
+            cfg.clone(),
+            "
         (define (foo n) (foo (* n 2)))
         (foo 1)
-        ").unwrap_err(),
-        RestrictError::IntegerLimitExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::IntegerLimitExceeded
+    );
 
-    assert_matches_re!(run(cfg.clone(), "
+    assert_matches_re!(
+        run(
+            cfg.clone(),
+            "
         (define (foo n) (foo (/ n 2)))
         (foo 1)
-        ").unwrap_err(),
-        RestrictError::IntegerLimitExceeded);
+        "
+        ).unwrap_err(),
+        RestrictError::IntegerLimitExceeded
+    );
 }
 
 #[test]
 fn test_restrict_syntax() {
-    assert_matches_re!(run(
-        RestrictConfig{
-            max_syntax_nesting: 50,
-            .. RestrictConfig::permissive()
-        },
+    assert_matches_re!(
+        run(
+            RestrictConfig {
+                max_syntax_nesting: 50,
+                ..RestrictConfig::permissive()
+            },
+            "
+        ((((((((((((((((((((((((((((((((((((((((((((((((((
+        ((((((((((((((((((((((((((((((((((((((((((((((((((
+        ))))))))))))))))))))))))))))))))))))))))))))))))))
+        ))))))))))))))))))))))))))))))))))))))))))))))))))
         "
-        ((((((((((((((((((((((((((((((((((((((((((((((((((
-        ((((((((((((((((((((((((((((((((((((((((((((((((((
-        ))))))))))))))))))))))))))))))))))))))))))))))))))
-        ))))))))))))))))))))))))))))))))))))))))))))))))))
-        ").unwrap_err(),
-        RestrictError::MaxSyntaxNestingExceeded);
+        ).unwrap_err(),
+        RestrictError::MaxSyntaxNestingExceeded
+    );
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,9 +1,6 @@
 extern crate ketos;
 
-use ketos::{
-    BuiltinModuleLoader, FileModuleLoader, ModuleLoader,
-    Error, Interpreter,
-};
+use ketos::{BuiltinModuleLoader, Error, FileModuleLoader, Interpreter, ModuleLoader};
 
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};
@@ -14,8 +11,7 @@ fn run_file(path: &Path) -> Result<(), Error> {
     loader.set_read_bytecode(false);
     loader.set_write_bytecode(false);
 
-    let interp = Interpreter::with_loader(
-        Box::new(BuiltinModuleLoader.chain(loader)));
+    let interp = Interpreter::with_loader(Box::new(BuiltinModuleLoader.chain(loader)));
 
     interp.run_file(path)
 }
@@ -28,7 +24,9 @@ fn test_run() {
     for ent in dir {
         let ent = ent.expect("failed to read dir entry");
         let fname = ent.file_name();
-        let name = fname.to_str().expect("failed to convert filename to string");
+        let name = fname
+            .to_str()
+            .expect("failed to convert filename to string");
 
         if name.starts_with("test-") && name.ends_with(".ket") {
             run_file(&ent.path()).unwrap();

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,7 +1,9 @@
-#[macro_use] extern crate assert_matches;
+#[macro_use]
+extern crate assert_matches;
 
 extern crate ketos;
-#[macro_use] extern crate ketos_derive;
+#[macro_use]
+extern crate ketos_derive;
 
 use ketos::{Error, ExecError, FromValue, Interpreter, Value};
 
@@ -45,14 +47,22 @@ fn test_struct() {
     assert_eq!(conv::<String>(&interp, "(. foo :name)").unwrap(), "foo");
     assert_eq!(conv::<u32>(&interp, "(. foo :num)").unwrap(), 123);
 
-    assert_matches!(eval(&interp, "(. foo :lolwut)").unwrap_err(),
-        Error::ExecError(ExecError::FieldError{..}));
+    assert_matches!(
+        eval(&interp, "(. foo :lolwut)").unwrap_err(),
+        Error::ExecError(ExecError::FieldError { .. })
+    );
 
     eval(&interp, r#"(define bar (.= foo :name "bar"))"#).unwrap();
 
     assert_eq!(conv::<String>(&interp, "(. bar :name)").unwrap(), "bar");
     assert_eq!(conv::<u32>(&interp, "(. bar :num)").unwrap(), 123);
 
-    assert_eq!(conv::<bool>(&interp, "(is-instance Foo foo)").unwrap(), true);
-    assert_eq!(conv::<bool>(&interp, "(is-instance Bar foo)").unwrap(), false);
+    assert_eq!(
+        conv::<bool>(&interp, "(is-instance Foo foo)").unwrap(),
+        true
+    );
+    assert_eq!(
+        conv::<bool>(&interp, "(is-instance Bar foo)").unwrap(),
+        false
+    );
 }

--- a/tests/value_encode.rs
+++ b/tests/value_encode.rs
@@ -2,14 +2,15 @@
 
 extern crate ketos;
 extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use ketos::{
-    BuiltinModuleLoader, FileModuleLoader, ModuleLoader,
-    Error, Interpreter, decode_value, encode_value,
+    decode_value, encode_value, BuiltinModuleLoader, Error, FileModuleLoader, Interpreter,
+    ModuleLoader,
 };
 
 macro_rules! map {
@@ -21,24 +22,26 @@ macro_rules! map {
 }
 
 macro_rules! test {
-    ( $a:expr , $b:expr ) => { {
-        let interp = interp(&format!(r#"
+    ( $a:expr , $b:expr ) => {{
+        let interp = interp(&format!(
+            r#"
             (define (give v)
               (assert-eq v '{0}))
             (define (take) '{0})
-            "#, $b)).unwrap();
+            "#,
+            $b
+        )).unwrap();
 
         let v = $a;
 
-        interp.call("give", vec![
-            encode_value(interp.scope(), &v).unwrap(),
-        ]).unwrap();
+        interp
+            .call("give", vec![encode_value(interp.scope(), &v).unwrap()])
+            .unwrap();
 
-        let v2 = decode_value(interp.scope(),
-            &interp.call("take", vec![]).unwrap()).unwrap();
+        let v2 = decode_value(interp.scope(), &interp.call("take", vec![]).unwrap()).unwrap();
 
         assert_eq!(v, v2);
-    } }
+    }};
 }
 
 fn interp(code: &str) -> Result<Interpreter, Error> {
@@ -47,8 +50,7 @@ fn interp(code: &str) -> Result<Interpreter, Error> {
     loader.set_read_bytecode(false);
     loader.set_write_bytecode(false);
 
-    let interp = Interpreter::with_loader(
-        Box::new(BuiltinModuleLoader.chain(loader)));
+    let interp = Interpreter::with_loader(Box::new(BuiltinModuleLoader.chain(loader)));
 
     interp.run_code("(use test (assert-eq))", None)?;
     interp.run_code(code, None)?;
@@ -63,11 +65,10 @@ struct StructA {
     c: String,
 }
 
-const STRUCT_0: &'static str =
-    r#"(StructA (:a 123 :b #'x' :c "foo"))"#;
+const STRUCT_0: &'static str = r#"(StructA (:a 123 :b #'x' :c "foo"))"#;
 
 fn struct_0() -> StructA {
-    StructA{
+    StructA {
         a: 123,
         b: 'x',
         c: "foo".to_owned(),
@@ -80,21 +81,19 @@ struct StructB {
     b: BTreeMap<String, String>,
 }
 
-const STRUCT_1: &'static str =
-    r#"(StructB (:a () :b ()))"#;
+const STRUCT_1: &'static str = r#"(StructB (:a () :b ()))"#;
 
 fn struct_1() -> StructB {
-    StructB{
+    StructB {
         a: vec![],
         b: map!(),
     }
 }
 
-const STRUCT_2: &'static str =
-    r#"(StructB (:a (1 2 3) :b (("a" "b") ("c" "d"))))"#;
+const STRUCT_2: &'static str = r#"(StructB (:a (1 2 3) :b (("a" "b") ("c" "d"))))"#;
 
 fn struct_2() -> StructB {
-    StructB{
+    StructB {
         a: vec![1, 2, 3],
         b: map!("a".to_owned() => "b".to_owned(), "c".to_owned() => "d".to_owned()),
     }
@@ -103,8 +102,7 @@ fn struct_2() -> StructB {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct StructC(u8, (u16, u32), [i32; 2]);
 
-const STRUCT_3: &'static str =
-    "(StructC (1 (2 3) (4 5)))";
+const STRUCT_3: &'static str = "(StructC (1 (2 3) (4 5)))";
 
 fn struct_3() -> StructC {
     StructC(1, (2, 3), [4, 5])
@@ -113,10 +111,11 @@ fn struct_3() -> StructC {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct StructD;
 
-const STRUCT_4: &'static str =
-    "(StructD ())";
+const STRUCT_4: &'static str = "(StructD ())";
 
-fn struct_4() -> StructD { StructD }
+fn struct_4() -> StructD {
+    StructD
+}
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct StructE {
@@ -126,16 +125,22 @@ struct StructE {
     d: StructD,
 }
 
-const STRUCT_5: &'static str =
-    r#"(StructE (:a (StructA (:a -1 :b #'.' :c "lol"))
+const STRUCT_5: &'static str = r#"(StructE (:a (StructA (:a -1 :b #'.' :c "lol"))
                  :b (StructB (:a (0) :b (("a" "b"))))
                  :c (StructC (2 (1 0) (-1 -2)))
                  :d (StructD ())))"#;
 
 fn struct_5() -> StructE {
-    StructE{
-        a: StructA{a: -1, b: '.', c: "lol".to_owned()},
-        b: StructB{a: vec![0], b: map!("a".to_owned() => "b".to_owned())},
+    StructE {
+        a: StructA {
+            a: -1,
+            b: '.',
+            c: "lol".to_owned(),
+        },
+        b: StructB {
+            a: vec![0],
+            b: map!("a".to_owned() => "b".to_owned()),
+        },
         c: StructC(2, (1, 0), [-1, -2]),
         d: StructD,
     }
@@ -156,35 +161,34 @@ enum Enum {
     Alpha,
     Beta(i32),
     Gamma(char, ()),
-    Delta{a: String, b: u32},
+    Delta { a: String, b: u32 },
 }
 
-const ENUM_0: &'static str =
-    "(Enum Alpha ())";
+const ENUM_0: &'static str = "(Enum Alpha ())";
 
 fn enum_0() -> Enum {
     Enum::Alpha
 }
 
-const ENUM_1: &'static str =
-    "(Enum Beta (1))";
+const ENUM_1: &'static str = "(Enum Beta (1))";
 
 fn enum_1() -> Enum {
     Enum::Beta(1)
 }
 
-const ENUM_2: &'static str =
-    "(Enum Gamma (#'a' ()))";
+const ENUM_2: &'static str = "(Enum Gamma (#'a' ()))";
 
 fn enum_2() -> Enum {
     Enum::Gamma('a', ())
 }
 
-const ENUM_3: &'static str =
-    r#"(Enum Delta (:a "foo" :b 123))"#;
+const ENUM_3: &'static str = r#"(Enum Delta (:a "foo" :b 123))"#;
 
 fn enum_3() -> Enum {
-    Enum::Delta{a: "foo".to_owned(), b: 123}
+    Enum::Delta {
+        a: "foo".to_owned(),
+        b: 123,
+    }
 }
 
 #[test]
@@ -196,23 +200,29 @@ fn test_enum() {
 }
 
 macro_rules! de {
-    ( $ty:ty => $e:expr ) => { {
-        let interp = interp(&format!("
+    ( $ty:ty => $e:expr ) => {{
+        let interp = interp(&format!(
+            "
             (define (make) '{})
-            ", $e)).unwrap();
+            ",
+            $e
+        )).unwrap();
 
-        decode_value::<$ty>(interp.scope(),
-            &interp.call("make", vec![]).unwrap())
-    } }
+        decode_value::<$ty>(interp.scope(), &interp.call("make", vec![]).unwrap())
+    }};
 }
 
 #[test]
 fn test_primitive() {
-    assert_eq!(de!((u32, String) => r#"(1 "foo")"#).unwrap(),
-        (1, "foo".to_owned()));
+    assert_eq!(
+        de!((u32, String) => r#"(1 "foo")"#).unwrap(),
+        (1, "foo".to_owned())
+    );
     assert_eq!(de!(Vec<u32> => "(1 2 3)").unwrap(), [1, 2, 3]);
-    assert_eq!(de!(BTreeMap<u32, u32> => "((1 2) (3 4))").unwrap(),
-        map!(1 => 2, 3 => 4));
+    assert_eq!(
+        de!(BTreeMap<u32, u32> => "((1 2) (3 4))").unwrap(),
+        map!(1 => 2, 3 => 4)
+    );
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -225,10 +235,14 @@ fn test_option() {
     assert_eq!(de!(Option<i32> => "()").unwrap(), None);
     assert_eq!(de!(Option<i32> => "1").unwrap(), Some(1));
 
-    assert_eq!(de!(OptStruct => "(OptStruct (:a 1))").unwrap(),
-        OptStruct{a: Some(1)});
-    assert_eq!(de!(OptStruct => "(OptStruct (:a ()))").unwrap(),
-        OptStruct{a: None});
+    assert_eq!(
+        de!(OptStruct => "(OptStruct (:a 1))").unwrap(),
+        OptStruct { a: Some(1) }
+    );
+    assert_eq!(
+        de!(OptStruct => "(OptStruct (:a ()))").unwrap(),
+        OptStruct { a: None }
+    );
 }
 
 #[test]


### PR DESCRIPTION
I have emacs setup to run `rustfmt` on save of a Rust file. This meant that a single 1 line change, modified the whole source file because the formatting changed.

This PR runs `cargo fmt` on the whole project so that it is formatted in a standard way.

If you do not like rustfmt, please reject this PR and I will make all followup PRs without automatic formatting enabled.

Link to rustfmt: https://github.com/rust-lang-nursery/rustfmt