### PR TITLE
Fixing trivial clippy warnings

### DIFF
--- a/src/ketos/bytecode.rs
+++ b/src/ketos/bytecode.rs
@@ -814,7 +814,7 @@ impl<'a> CodeReader<'a> {
     /// Creates a new `CodeReader` wrapping a series of bytes.
     /// The first instruction will be read from `offset`.
     pub fn new(bytes: &[u8], offset: usize) -> CodeReader {
-        CodeReader{bytes: bytes, offset: offset}
+        CodeReader { bytes, offset }
     }
 
     /// Returns the offset, in bytes, at which the next instruction will be read.

--- a/src/ketos/bytes.rs
+++ b/src/ketos/bytes.rs
@@ -94,7 +94,6 @@ macro_rules! impl_eq_vec {
     ( $lhs:ty, $rhs:ty ) => {
         impl<'a> PartialEq<$rhs> for $lhs {
             fn eq(&self, rhs: &$rhs) -> bool { self[..] == rhs[..] }
-            fn ne(&self, rhs: &$rhs) -> bool { self[..] != rhs[..] }
         }
     }
 }
@@ -104,12 +103,10 @@ macro_rules! impl_eq_array {
         $(
             impl PartialEq<[u8; $n]> for Bytes {
                 fn eq(&self, rhs: &[u8; $n]) -> bool { self[..] == rhs[..] }
-                fn ne(&self, rhs: &[u8; $n]) -> bool { self[..] != rhs[..] }
             }
 
             impl<'a> PartialEq<&'a [u8; $n]> for Bytes {
                 fn eq(&self, rhs: &&'a [u8; $n]) -> bool { self[..] == rhs[..] }
-                fn ne(&self, rhs: &&'a [u8; $n]) -> bool { self[..] != rhs[..] }
             }
         )+
     }

--- a/src/ketos/encode.rs
+++ b/src/ketos/encode.rs
@@ -25,7 +25,7 @@ use structs::{StructDef, StructValueDef};
 use value::Value;
 
 /// First four bytes written to a compiled bytecode file.
-pub const MAGIC_NUMBER: &'static [u8; 4] = b"\0MUR";
+pub const MAGIC_NUMBER: &[u8; 4] = b"\0MUR";
 
 /// Error in decoding bytecode file format
 #[derive(Debug)]
@@ -426,13 +426,13 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
                 let c = self.read_u32()?;
                 from_u32(c)
                     .map(Value::Char)
-                    .ok_or(DecodeError::InvalidChar(c))
+                    .ok_or_else(|| DecodeError::InvalidChar(c))
             }
             STRING => self.read_string().map(|s| s.into()),
             BYTES => self.read_byte_string().map(|s| s.into()),
             PATH => self.read_string().map(|s| PathBuf::from(s).into()),
             // XXX: Decoding struct values is not implemented
-            STRUCT => return Err(DecodeError::InvalidType(STRUCT)),
+            STRUCT => Err(DecodeError::InvalidType(STRUCT)),
             STRUCT_DEF => {
                 let name = self.read_name(names)?;
                 let n = self.read_uint()?;
@@ -570,7 +570,7 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
 
     fn read_name(&mut self, names: &NameInputConversion) -> Result<Name, DecodeError> {
         let n = self.read_uint()?;
-        names.get(n).ok_or(DecodeError::InvalidName(n))
+        names.get(n).ok_or_else(|| DecodeError::InvalidName(n))
     }
 
     fn read_string(&mut self) -> Result<&'data str, DecodeError> {

--- a/src/ketos/function.rs
+++ b/src/ketos/function.rs
@@ -664,7 +664,7 @@ fn try_pow(ctx: &Context, base: &Integer, mut exp: u32) -> Result<Integer, Error
     }
 
     if exp == 0 {
-        return Ok(Integer::one().into());
+        return Ok(Integer::one());
     }
 
     let mut base = base.clone();
@@ -675,7 +675,7 @@ fn try_pow(ctx: &Context, base: &Integer, mut exp: u32) -> Result<Integer, Error
     }
 
     if exp == 1 {
-        return Ok(base.into());
+        return Ok(base);
     }
 
     let mut acc = base.clone();
@@ -1421,10 +1421,10 @@ fn fn_elt(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 
     match *li {
         Value::List(ref li) => li.get(idx).cloned()
-            .ok_or(From::from(ExecError::OutOfBounds(idx))),
+            .ok_or_else(|| From::from(ExecError::OutOfBounds(idx))),
         Value::Bytes(ref b) => b.get(idx).cloned()
             .map(|b| b.into())
-            .ok_or(From::from(ExecError::OutOfBounds(idx))),
+            .ok_or_else(|| From::from(ExecError::OutOfBounds(idx))),
         ref v => Err(From::from(ExecError::expected("indexable sequence", v)))
     }
 }
@@ -1722,7 +1722,7 @@ fn fn_first(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 fn fn_second(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     match args[0] {
         Value::List(ref mut li) => li.get(1).cloned()
-            .ok_or(From::from(ExecError::OutOfBounds(1))),
+            .ok_or_else(|| From::from(ExecError::OutOfBounds(1))),
         ref v => Err(From::from(ExecError::expected("list", v)))
     }
 }
@@ -1924,7 +1924,7 @@ fn fn_int(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
         Value::Float(f) => match f {
             f if f.is_infinite() || f.is_nan() => Err(From::from(ExecError::Overflow)),
             f => Integer::from_f64(f)
-                .map(Value::Integer).ok_or(From::from(ExecError::Overflow)),
+                .map(Value::Integer).ok_or_else(|| From::from(ExecError::Overflow)),
         },
         Value::Integer(i) => Ok(i.into()),
         Value::Ratio(ref r) => Ok(r.to_integer().into()),
@@ -2012,7 +2012,7 @@ fn fn_rat(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
     if args.len() == 1 {
         match args[0].take() {
             Value::Float(f) => Ratio::from_f64(f)
-                .map(Value::Ratio).ok_or(From::from(ExecError::Overflow)),
+                .map(Value::Ratio).ok_or_else(|| From::from(ExecError::Overflow)),
             Value::Integer(a) =>
                 Ok(Ratio::from_integer(a).into()),
             Value::Ratio(r) => Ok(r.into()),

--- a/src/ketos/integer.rs
+++ b/src/ketos/integer.rs
@@ -439,15 +439,10 @@ impl PartialEq<Integer> for Ratio {
     fn eq(&self, rhs: &Integer) -> bool {
         self.denom().is_one() && self.numer() == rhs
     }
-
-    fn ne(&self, rhs: &Integer) -> bool {
-        !self.denom().is_one() || self.numer() != rhs
-    }
 }
 
 impl PartialEq<Ratio> for Integer {
     fn eq(&self, rhs: &Ratio) -> bool { rhs == self }
-    fn ne(&self, rhs: &Ratio) -> bool { rhs != self }
 }
 
 impl fmt::Display for Integer {

--- a/src/ketos/interpreter.rs
+++ b/src/ketos/interpreter.rs
@@ -239,9 +239,7 @@ impl Interpreter {
 
     /// Creates a new `Interpreter` using the given `Context` instance.
     pub fn with_context(context: Context) -> Interpreter {
-        Interpreter{
-            context: context,
-        }
+        Interpreter{ context }
     }
 
     /// Creates a new `Interpreter` using the given `Scope` instance.
@@ -359,7 +357,7 @@ impl Interpreter {
     pub fn call(&self, name: &str, args: Vec<Value>) -> Result<Value, Error> {
         let name = self.scope().borrow_names_mut().add(name);
 
-        let v = self.scope().get_value(name).ok_or(ExecError::NameError(name))?;
+        let v = self.scope().get_value(name).ok_or_else(|| ExecError::NameError(name))?;
         self.call_value(v, args)
     }
 

--- a/src/ketos/io.rs
+++ b/src/ketos/io.rs
@@ -17,9 +17,7 @@ pub struct GlobalIo {
 impl GlobalIo {
     /// Creates a `GlobalIo` instance using the given `stdout` writer.
     pub fn new(stdout: Rc<SharedWrite>) -> GlobalIo {
-        GlobalIo{
-            stdout: stdout,
-        }
+        GlobalIo{ stdout }
     }
 
     /// Creates a `GlobalIo` instance whose `stdout` ignores all output.
@@ -159,10 +157,7 @@ pub struct File {
 impl File {
     /// Creates a new `File` from an open filehandle and path.
     pub fn new(file: fs::File, path: PathBuf) -> File {
-        File{
-            file: file,
-            path: path,
-        }
+        File{ file, path }
     }
 }
 

--- a/src/ketos/lexer.rs
+++ b/src/ketos/lexer.rs
@@ -159,10 +159,7 @@ impl CodeMap {
         let begin = self.text.len() as BytePos;
 
         self.text.push_str(text);
-        self.files.push(File{
-            path: path,
-            begin: begin,
-        });
+        self.files.push(File{ path, begin });
 
         begin
     }
@@ -543,7 +540,7 @@ fn parse_number(input: &str) -> Result<(Token, usize), ParseErrorKind> {
                 }
             }
             '+' | '-' => {
-                if !(exp && !exp_digit) {
+                if exp_digit || !exp {
                     return Err(ParseErrorKind::InvalidLiteral);
                 }
                 exp_digit = true;

--- a/src/ketos/mod_code.rs
+++ b/src/ketos/mod_code.rs
@@ -258,7 +258,7 @@ fn fn_get_const(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
             let n = usize::from_value_ref(&args[1])?;
 
             let v = l.code.consts.get(n)
-                .ok_or(ExecError::OutOfBounds(n))?;
+                .ok_or_else(|| ExecError::OutOfBounds(n))?;
 
             Ok(v.clone())
         }
@@ -273,7 +273,7 @@ fn fn_get_value(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
             let n = usize::from_value_ref(&args[1])?;
 
             let v = l.values.as_ref().and_then(|v| v.get(n))
-                .ok_or(ExecError::OutOfBounds(n))?;
+                .ok_or_else(|| ExecError::OutOfBounds(n))?;
 
             Ok(v.clone())
         }
@@ -288,7 +288,7 @@ fn fn_get_value(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 ///
 /// When given no parameters, the documentation for the current scope is returned.
 fn fn_module_documentation(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
-    if args.len() == 0 {
+    if args.is_empty() {
         return Ok(ctx.scope().with_module_doc(|d| d.into())
             .unwrap_or(Value::Unit));
     }

--- a/src/ketos/module.rs
+++ b/src/ketos/module.rs
@@ -36,10 +36,7 @@ impl Module {
     /// Creates a new module using the given scope.
     pub fn new(name: &str, scope: Scope) -> Module {
         let name = scope.add_name(name);
-        Module{
-            name: name,
-            scope: scope,
-        }
+        Module{ name, scope }
     }
 }
 
@@ -81,9 +78,9 @@ impl ModuleBuilder {
         self.add_value_with_name(name, |name| Value::Function(Function{
                 name: name,
                 sys_fn: SystemFn{
-                    arity: arity,
-                    callback: callback,
-                    doc: doc,
+                    arity,
+                    callback,
+                    doc,
                 },
             }))
     }
@@ -356,10 +353,10 @@ pub struct FileModuleLoader {
 }
 
 /// File extension for `ketos` source files.
-pub const FILE_EXTENSION: &'static str = "ket";
+pub const FILE_EXTENSION: &str = "ket";
 
 /// File extension for `ketos` compiled bytecode files.
-pub const COMPILED_FILE_EXTENSION: &'static str = "ketc";
+pub const COMPILED_FILE_EXTENSION: &str = "ketc";
 
 impl FileModuleLoader {
     /// Creates a new `FileModuleLoader` that will search the current

--- a/src/ketos/name.rs
+++ b/src/ketos/name.rs
@@ -588,7 +588,7 @@ impl<T> NameMapSlice<T> {
     /// Creates a `NameMapSlice` wrapping the given boxed slice,
     /// which must already be sorted by name.
     fn new(values: Box<[(Name, T)]>) -> NameMapSlice<T> {
-        NameMapSlice{values: values}
+        NameMapSlice{ values }
     }
 
     /// Returns whether the map contains a value for the given name.
@@ -735,7 +735,7 @@ impl NameSetSlice {
     /// Creates a `NameSetSlice` wrapping the given boxed slice,
     /// which must already be sorted.
     fn new(map: NameMapSlice<()>) -> NameSetSlice {
-        NameSetSlice{map: map}
+        NameSetSlice{ map }
     }
 
     /// Returns whether the set contains the given name.

--- a/src/ketos/parser.rs
+++ b/src/ketos/parser.rs
@@ -15,7 +15,7 @@ use restrict::RestrictError;
 use string;
 use value::Value;
 
-const MODULE_DOC_COMMENT: &'static str = ";;;";
+const MODULE_DOC_COMMENT: &str = ";;;";
 
 /// Parses a stream of tokens into an expression.
 pub struct Parser<'a, 'lex> {
@@ -37,10 +37,7 @@ pub struct ParseError {
 impl ParseError {
     /// Creates a new `ParseError`.
     pub fn new(span: Span, kind: ParseErrorKind) -> ParseError {
-        ParseError{
-            span: span,
-            kind: kind,
-        }
+        ParseError{ span, kind }
     }
 }
 
@@ -496,7 +493,7 @@ fn parse_path(s: &str) -> Result<PathBuf, ParseError> {
     } else {
         string::parse_string(&s[2..], 0)?
     };
-    Ok(PathBuf::from(s).into())
+    Ok(PathBuf::from(s))
 }
 
 fn parse_string(s: &str) -> Result<String, ParseError> {

--- a/src/ketos/rc_vec.rs
+++ b/src/ketos/rc_vec.rs
@@ -183,7 +183,6 @@ macro_rules! impl_eq_str {
     ( $lhs:ty, $rhs:ty ) => {
         impl<'a> PartialEq<$rhs> for $lhs {
             fn eq(&self, rhs: &$rhs) -> bool { self[..] == rhs[..] }
-            fn ne(&self, rhs: &$rhs) -> bool { self[..] != rhs[..] }
         }
     }
 }
@@ -373,7 +372,6 @@ macro_rules! impl_eq_vec {
     ( $lhs:ty, $rhs:ty ) => {
         impl<'a, A, B> PartialEq<$rhs> for $lhs where A: PartialEq<B> {
             fn eq(&self, rhs: &$rhs) -> bool { self[..] == rhs[..] }
-            fn ne(&self, rhs: &$rhs) -> bool { self[..] != rhs[..] }
         }
     }
 }
@@ -383,12 +381,10 @@ macro_rules! impl_eq_array {
         $(
             impl<A, B> PartialEq<[B; $n]> for RcVec<A> where A: PartialEq<B> {
                 fn eq(&self, rhs: &[B; $n]) -> bool { self[..] == rhs[..] }
-                fn ne(&self, rhs: &[B; $n]) -> bool { self[..] != rhs[..] }
             }
 
             impl<'a, A, B> PartialEq<&'a [B; $n]> for RcVec<A> where A: PartialEq<B> {
                 fn eq(&self, rhs: &&'a [B; $n]) -> bool { self[..] == rhs[..] }
-                fn ne(&self, rhs: &&'a [B; $n]) -> bool { self[..] != rhs[..] }
             }
         )+
     }

--- a/src/ketos/string.rs
+++ b/src/ketos/string.rs
@@ -113,14 +113,13 @@ impl<'a> StringReader<'a> {
 
     fn parse_byte_string(&mut self) -> Result<(Vec<u8>, usize), ParseError> {
         let mut res = Vec::new();
-        let mut n_hash = 0;
-
-        if self.ty == StringType::Raw {
-            n_hash = self.parse_raw_prefix()?;
+        let n_hash = if self.ty == StringType::Raw {
+            self.parse_raw_prefix()?
         } else {
             self.expect('"', |slf, ch| ParseError::new(slf.span_one(),
-                ParseErrorKind::InvalidChar(ch)))?;
-        }
+                                                       ParseErrorKind::InvalidChar(ch)))?;
+            0
+        };
 
         loop {
             match self.consume_char()? {
@@ -150,14 +149,13 @@ impl<'a> StringReader<'a> {
     fn parse_string(&mut self) -> Result<(String, usize), ParseError> {
         let mut res = String::new();
 
-        let mut n_hash = 0;
-
-        if self.ty == StringType::Raw {
-            n_hash = self.parse_raw_prefix()?;
+        let n_hash = if self.ty == StringType::Raw {
+            self.parse_raw_prefix()?
         } else {
             self.expect('"', |slf, ch| ParseError::new(slf.span_one(),
-                ParseErrorKind::InvalidChar(ch)))?;
-        }
+                                                       ParseErrorKind::InvalidChar(ch)))?;
+            0usize
+        };
 
         loop {
             match self.consume_char()? {

--- a/src/ketos/string_fmt.rs
+++ b/src/ketos/string_fmt.rs
@@ -1002,8 +1002,7 @@ impl<'fmt, 'names, 'value> StringFormatter<'fmt, 'names, 'value> {
                 n => n,
             };
 
-            let total_text = strs.iter().map(|s| s.len())
-                .fold(0, |a, b| a + b) as u32;
+            let total_text = strs.iter().map(|s| s.len() as u32).sum::<u32>();
             let cols = max(min_col, total_text + pads * min_pad);
             let cols = cols + ((cols + (col_inc - 1)) % col_inc);
             let total_pad = cols - total_text;
@@ -1715,7 +1714,7 @@ fn low_cardinal(n: u32) -> Cardinal {
     LOW_CARDINALS[(n - 1) as usize]
 }
 
-const MID_CARDINALS: &'static [Cardinal] = &[
+const MID_CARDINALS: &[Cardinal] = &[
     ("twenty", "twentieth"),
     ("thirty", "thirtieth"),
     ("forty", "fortieth"),
@@ -1726,7 +1725,7 @@ const MID_CARDINALS: &'static [Cardinal] = &[
     ("ninety", "ninetieth"),
 ];
 
-const LOW_CARDINALS: &'static [Cardinal] = &[
+const LOW_CARDINALS: &[Cardinal] = &[
     ("one", "first"),
     ("two", "second"),
     ("three", "third"),

--- a/src/ketos/structs.rs
+++ b/src/ketos/structs.rs
@@ -160,7 +160,7 @@ pub struct StructValueDef {
 impl StructValueDef {
     /// Creates a new `StructValueDef` from a mapping of field name to type name.
     pub fn new(fields: NameMapSlice<Name>) -> StructValueDef {
-        StructValueDef{fields: fields}
+        StructValueDef{ fields }
     }
 
     /// Returns a borrowed reference to the contained fields.
@@ -283,10 +283,7 @@ pub struct Struct {
 impl Struct {
     /// Creates a new `Struct` value with the given `StructDef` and field values.
     pub fn new(def: Rc<StructDef>, fields: Box<[Value]>) -> Struct {
-        Struct{
-            def: def,
-            fields: fields,
-        }
+        Struct{ def, fields }
     }
 
     /// Returns the struct definition.
@@ -339,10 +336,7 @@ fn ptr_eq<T>(a: *const T, b: *const T) -> bool {
 impl StructDef {
     /// Creates a new `StructDef` with the given name and fields.
     pub fn new(name: Name, def: Box<StructDefinition>) -> StructDef {
-        StructDef{
-            name: name,
-            def: def,
-        }
+        StructDef{ name, def }
     }
 
     /// Returns the struct name.

--- a/src/ketos/trace.rs
+++ b/src/ketos/trace.rs
@@ -24,10 +24,7 @@ pub struct Trace {
 impl Trace {
     /// Creates a new `Trace` from a series of items.
     pub fn new(items: Vec<TraceItem>, expr: Option<Value>) -> Trace {
-        Trace{
-            items: items,
-            expr: expr,
-        }
+        Trace{ items, expr }
     }
 
     /// Creates a new `Trace` from a single item.

--- a/src/ketos/value.rs
+++ b/src/ketos/value.rs
@@ -78,10 +78,7 @@ impl Value {
     /// Returns a value containing a foreign function.
     pub fn new_foreign_fn<F>(name: Name, f: F) -> Value
             where F: AnyValue + Fn(&Context, &mut [Value]) -> Result<Value, Error> {
-        Value::new_foreign(ForeignFn{
-            name: name,
-            f: f,
-        })
+        Value::new_foreign(ForeignFn{ name, f })
     }
 
     /// Compares two values; returns an error if the values cannot be compared.
@@ -302,8 +299,7 @@ impl Value {
                 let denom = r.denom().bits();
                 1 + numer + denom
             }
-            Value::Struct(ref s) =>
-                1 + s.fields().iter().map(|f| f.size()).fold(0, |a, b| a + b),
+            Value::Struct(ref s) => 1 + s.fields().iter().map(|f| f.size()).sum::<usize>(),
             Value::StructDef(ref d) => d.def().size(),
             Value::String(ref s) => 1 + s.len(),
             Value::Bytes(ref s) => 1 + s.len(),
@@ -312,11 +308,9 @@ impl Value {
             Value::CommaAt(ref v, _) |
             Value::Quasiquote(ref v, _) |
             Value::Quote(ref v, _) => 1 + v.size(),
-            Value::List(ref li) =>
-                1 + li.iter().map(|v| v.size()).fold(0, |a, b| a + b),
+            Value::List(ref li) => 1 + li.iter().map(|v| v.size()).sum::<usize>(),
             Value::Lambda(ref l) =>
-                1 + l.values.as_ref().map_or(0,
-                    |v| v.iter().map(|v| v.size()).fold(0, |a, b| a + b)),
+                1 + l.values.as_ref().map_or(0, |v| v.iter().map(|v| v.size()).sum()),
             Value::Foreign(ref v) => v.size(),
             _ => 1
         }


### PR DESCRIPTION
- Partial ne is automatically created
- Collapse `else { if ...` to `else if`
- Use `ok_or_else()` instead of `ok_or()` when calling functions
- Use `.sum()` instead of `.fold(0, |a, b| a + b)`
- Remove unneeded `.into()`
- Drop key name in struct literals where all key names === value names
- Use `.is_empty()` instead of `.len() == 0`