### PR TITLE
Clippy pass

### DIFF
--- a/examples/calling.rs
+++ b/examples/calling.rs
@@ -6,7 +6,7 @@ use ketos::{Interpreter, FromValueRef};
 
 fn main() {
     // First, create an interpreter.
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     // Run some code that defines a function.
     // This will insert the newly defined function into the interpreter scope.

--- a/examples/interop.rs
+++ b/examples/interop.rs
@@ -61,7 +61,7 @@ fn count(counter: &Counter) -> Result<u32, Error> {
 
 fn main() {
     // First, create an interpreter.
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     // Create a shared `Hello` value.
     let hello = Rc::new(Hello::new("world".into()));

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -20,7 +20,7 @@ struct Thing {
 
 fn main() {
     // First, create the interpreter.
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     // Before Ketos code can construct a Thing value, it needs to know about it.
     interp.scope().register_struct_value::<Thing>();

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -81,7 +81,7 @@ fn run() -> i32 {
 
     paths.extend(opts.include.into_iter().map(PathBuf::from));
 
-    let mut builder = Builder::new()
+    let mut builder = Builder::default()
         .search_paths(paths);
 
     if let Some(ref res) = opts.restrict {

--- a/src/ketos/bytecode.rs
+++ b/src/ketos/bytecode.rs
@@ -694,11 +694,11 @@ impl JumpInstruction {
     }
 
     /// Length, in bytes, of this jump instruction.
-    pub fn len(&self, short: bool) -> usize {
+    pub fn len(self, short: bool) -> usize {
         use self::JumpInstruction::*;
         let len = if short { 1 } else { 2 };
 
-        match *self {
+        match self {
             Jump |
             JumpIf |
             JumpIfNot |
@@ -838,12 +838,12 @@ impl<'a> CodeReader<'a> {
     }
 
     fn read_operand(&mut self) -> Result<u32, ExecError> {
-        let a = self.read_byte()? as u32;
+        let a = u32::from(self.read_byte()?);
         if a & 0x80 == 0 {
             Ok(a)
         } else {
             let a = (a & 0x7f) << 8;
-            let b = self.read_byte()? as u32;
+            let b = u32::from(self.read_byte()?);
             Ok(a | b)
         }
     }
@@ -862,9 +862,9 @@ pub struct CodeBlock {
     pub next: Option<u32>,
 }
 
-impl CodeBlock {
+impl Default for CodeBlock {
     /// Creates an empty `CodeBlock` with a small reserved buffer.
-    pub fn new() -> CodeBlock {
+    fn default() -> CodeBlock {
         CodeBlock{
             bytes: Vec::with_capacity(16),
             instr_part: None,
@@ -872,7 +872,9 @@ impl CodeBlock {
             next: None,
         }
     }
+}
 
+impl CodeBlock {
     /// Creates an empty `CodeBlock` without reserving data.
     pub fn empty() -> CodeBlock {
         CodeBlock{

--- a/src/ketos/compile.rs
+++ b/src/ketos/compile.rs
@@ -236,12 +236,12 @@ impl<'a> Compiler<'a> {
         Compiler{
             ctx: ctx.clone(),
             consts: Vec::new(),
-            blocks: vec![CodeBlock::new()],
+            blocks: vec![CodeBlock::default()],
             cur_block: 0,
             stack: Vec::new(),
             stack_offset: 0,
             captures: Vec::new(),
-            outer: outer,
+            outer,
             self_name: name,
             macro_recursion: 0,
             trace: Vec::new(),
@@ -347,7 +347,7 @@ impl<'a> Compiler<'a> {
 
         Ok(Code{
             name: None,
-            code: code,
+            code,
             consts: consts.into_boxed_slice(),
             kw_params: vec![].into_boxed_slice(),
             n_params: 0,
@@ -443,13 +443,13 @@ impl<'a> Compiler<'a> {
         let captures = replace(&mut self.captures, Vec::new());
 
         let code = Code{
-            name: name,
-            code: code,
+            name,
+            code,
             consts: consts.into_boxed_slice(),
             kw_params: kw_names.into_boxed_slice(),
             n_params: n_params as u32,
-            req_params: req_params,
-            flags: flags,
+            req_params,
+            flags,
             doc: None,
         };
 
@@ -488,8 +488,6 @@ impl<'a> Compiler<'a> {
                         if self.load_local_name(name)? {
                             self.push_instruction(Instruction::Push)?;
                             pushed_fn = true;
-                        } else if self.self_name == Some(name) {
-                            () // This is handled later
                         } else if self.is_macro(name) {
                             self.trace.push(TraceItem::CallMacro(
                                 self.ctx.scope().name(), name));
@@ -545,7 +543,7 @@ impl<'a> Compiler<'a> {
                                 if !sys_fn.arity.accepts(n_args) {
                                     self.set_trace_expr(&value);
                                     return Err(From::from(CompileError::ArityError{
-                                        name: name,
+                                        name,
                                         expected: sys_fn.arity,
                                         found: n_args,
                                     }));
@@ -889,7 +887,7 @@ impl<'a> Compiler<'a> {
         if !op.arity.accepts(n_args) {
             self.set_trace_expr(expr);
             Err(From::from(CompileError::ArityError{
-                name: name,
+                name,
                 expected: op.arity,
                 found: n_args,
             }))
@@ -1394,7 +1392,7 @@ impl<'a> Compiler<'a> {
 
     fn new_block(&mut self) -> u32 {
         let n = self.blocks.len() as u32;
-        self.blocks.push(CodeBlock::new());
+        self.blocks.push(CodeBlock::default());
         n
     }
 
@@ -1628,7 +1626,7 @@ fn eval_system_fn(compiler: &mut Compiler, name: Name, args: &[Value])
 
     if !sys_fn.arity.accepts(n_args) {
         return Err(From::from(CompileError::ArityError{
-            name: name,
+            name,
             expected: sys_fn.arity,
             found: n_args,
         }));

--- a/src/ketos/encode.rs
+++ b/src/ketos/encode.rs
@@ -134,11 +134,11 @@ pub fn read_bytecode<R: Read>(r: &mut R, path: &Path, ctx: &Context)
 
     r.read_exact(&mut buf)
         .map_err(|e| IoError::new(IoMode::Read, path, e))?;
-    check_magic_number(&buf)?;
+    check_magic_number(buf)?;
 
     r.read_exact(&mut buf)
         .map_err(|e| IoError::new(IoMode::Read, path, e))?;
-    check_version(&buf)?;
+    check_version(buf)?;
 
     let mut buf = Vec::new();
     r.read_to_end(&mut buf)
@@ -147,7 +147,7 @@ pub fn read_bytecode<R: Read>(r: &mut R, path: &Path, ctx: &Context)
     let mut dec = ValueDecoder::new(ctx, &buf);
 
     let n_names = dec.read_uint()?;
-    let mut names = NameInputConversion::new();
+    let mut names = NameInputConversion::default();
 
     {
         let mut name_store = ctx.scope().names().borrow_mut();
@@ -239,12 +239,12 @@ pub fn read_bytecode<R: Read>(r: &mut R, path: &Path, ctx: &Context)
     Ok(ModuleCode{
         code: exprs,
         constants: consts,
-        macros: macros,
-        values: values,
+        macros,
+        values,
         exports: exports.into_slice(),
-        imports: imports,
+        imports,
         module_doc: doc,
-        docs: docs,
+        docs,
     })
 }
 
@@ -340,16 +340,16 @@ pub fn write_bytecode<W: Write>(w: &mut W, path: &Path, module: &ModuleCode,
     Ok(())
 }
 
-fn check_magic_number(num: &[u8; 4]) -> Result<(), DecodeError> {
-    if num == MAGIC_NUMBER {
+fn check_magic_number(num: [u8; 4]) -> Result<(), DecodeError> {
+    if &num == MAGIC_NUMBER {
         Ok(())
     } else {
-        Err(DecodeError::IncorrectMagicNumber(*num))
+        Err(DecodeError::IncorrectMagicNumber(num))
     }
 }
 
-fn check_version(num: &[u8; 4]) -> Result<(), DecodeError> {
-    let version = BigEndian::read_u32(num);
+fn check_version(num: [u8; 4]) -> Result<(), DecodeError> {
+    let version = BigEndian::read_u32(&num);
 
     if version == BYTECODE_VERSION {
         Ok(())
@@ -371,7 +371,7 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
     fn new(ctx: &'a Context, data: &'data [u8]) -> ValueDecoder<'a, 'data> {
         ValueDecoder{
             data: Cursor::new(data),
-            ctx: ctx,
+            ctx,
         }
     }
 
@@ -450,22 +450,22 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
                 Ok(Value::StructDef(Rc::new(StructDef::new(name, Box::new(def)))))
             }
             QUASI_QUOTE => {
-                let n = self.read_u8()? as u32;
+                let n = u32::from(self.read_u8()?);
                 self.read_value(names).map(|v| v.quasiquote(n))
             }
             QUASI_QUOTE_ONE => self.read_value(names).map(|v| v.quasiquote(1)),
             COMMA => {
-                let n = self.read_u8()? as u32;
+                let n = u32::from(self.read_u8()?);
                 self.read_value(names).map(|v| v.comma(n))
             }
             COMMA_ONE => self.read_value(names).map(|v| v.comma(1)),
             COMMA_AT => {
-                let n = self.read_u8()? as u32;
+                let n = u32::from(self.read_u8()?);
                 self.read_value(names).map(|v| v.comma_at(n))
             }
             COMMA_AT_ONE => self.read_value(names).map(|v| v.comma_at(1)),
             QUOTE => {
-                let n = self.read_u8()? as u32;
+                let n = u32::from(self.read_u8()?);
                 self.read_value(names).map(|v| v.quote(n))
             }
             QUOTE_ONE => self.read_value(names).map(|v| v.quote(1)),
@@ -499,7 +499,7 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
     fn read_code(&mut self, names: &NameInputConversion) -> Result<Code, DecodeError> {
         use bytecode::code_flags::*;
 
-        let flags = self.read_u8()? as u32;
+        let flags = u32::from(self.read_u8()?);
 
         if flags & ALL_FLAGS != flags {
             return Err(DecodeError::InvalidCodeFlags(flags));
@@ -557,14 +557,14 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
         }
 
         Ok(Code{
-            name: name,
+            name,
             consts: consts.into_boxed_slice(),
             code: code.into_boxed_slice(),
             kw_params: kw_params.into_boxed_slice(),
-            n_params: n_params,
-            req_params: req_params,
-            flags: flags,
-            doc: doc,
+            n_params,
+            req_params,
+            flags,
+            doc,
         })
     }
 
@@ -608,13 +608,13 @@ impl<'a, 'data> ValueDecoder<'a, 'data> {
     }
 
     fn read_uint(&mut self) -> Result<u32, DecodeError> {
-        let hi = self.read_u8()? as u32;
+        let hi = u32::from(self.read_u8()?);
 
         if hi & 0x80 == 0 {
             Ok(hi)
         } else {
             let hi = (hi & 0x7f) << 8;
-            let lo = self.read_u8()? as u32;
+            let lo = u32::from(self.read_u8()?);
             Ok(hi | lo)
         }
     }

--- a/src/ketos/exec.rs
+++ b/src/ketos/exec.rs
@@ -69,8 +69,8 @@ impl Context {
     /// Creates a new execution context.
     pub fn new(scope: Scope, restrict: RestrictConfig) -> Context {
         Context{
-            scope: scope,
-            restrict: restrict,
+            scope,
+            restrict,
             run_start: Cell::new(None),
             run_level: Cell::new(0),
             memory_held: Cell::new(0),
@@ -265,7 +265,7 @@ impl ExecError {
     /// type is expected, but some other type of value is found.
     pub fn expected(expected: &'static str, v: &Value) -> ExecError {
         ExecError::TypeError{
-            expected: expected,
+            expected,
             found: v.type_name(),
             value: Some(v.clone()),
         }
@@ -276,9 +276,9 @@ impl ExecError {
     pub fn expected_field(struct_name: Name, field: Name,
             expected: Name, v: &Value) -> ExecError {
         ExecError::FieldTypeError{
-            struct_name: struct_name,
-            field: field,
-            expected: expected,
+            struct_name,
+            field,
+            expected,
             found: v.type_name(),
             value: Some(v.clone()),
         }
@@ -519,7 +519,7 @@ impl Machine {
         }
 
         self.start(StackFrame{
-            code: code,
+            code,
             scope: scope.clone(),
             values: None,
             iptr: 0,
@@ -565,7 +565,7 @@ impl Machine {
 
         self.start(StackFrame{
             code: lambda.code,
-            scope: scope,
+            scope,
             values: lambda.values,
             iptr: 0,
             sptr: 0,
@@ -846,11 +846,11 @@ impl Machine {
 
         let old_frame = replace(frame, StackFrame{
             code: lambda.code,
-            scope: scope,
+            scope,
             values: lambda.values,
             iptr: 0,
             sptr: self.stack.len() as u32 - n_args,
-            fn_on_stack: fn_on_stack,
+            fn_on_stack,
         });
 
         self.save_frame(old_frame)?;

--- a/src/ketos/function.rs
+++ b/src/ketos/function.rs
@@ -340,7 +340,7 @@ impl Lambda {
     /// Creates a new `Lambda`.
     pub fn new(code: Rc<Code>, scope: &Scope) -> Lambda {
         Lambda{
-            code: code,
+            code,
             scope: Rc::downgrade(scope),
             values: None,
         }
@@ -349,8 +349,8 @@ impl Lambda {
     /// Creates a new `Lambda` enclosing a set of values.
     pub fn new_closure(code: Rc<Code>, scope: WeakScope, values: Box<[Value]>) -> Lambda {
         Lambda{
-            code: code,
-            scope: scope,
+            code,
+            scope,
             values: Some(Rc::new(values)),
         }
     }

--- a/src/ketos/interpreter.rs
+++ b/src/ketos/interpreter.rs
@@ -32,7 +32,7 @@ use value::Value;
 /// ```
 /// # use ketos::Builder;
 ///
-/// let interp = Builder::new()
+/// let interp = Builder::default()
 ///     .name("foo")
 ///     // ...
 ///     .finish();
@@ -59,9 +59,9 @@ macro_rules! exclude {
     }
 }
 
-impl Builder {
+impl Default for Builder {
     /// Creates a new `Builder`.
-    pub fn new() -> Builder {
+    fn default() -> Builder {
         Builder{
             name: None,
             context: None,
@@ -73,7 +73,9 @@ impl Builder {
             search_paths: None,
         }
     }
+}
 
+impl Builder {
     /// Sets the name of the new scope.
     pub fn name(mut self, name: &'static str) -> Self {
         exclude!(self.context, "name", "context");
@@ -173,11 +175,11 @@ impl Builder {
     fn build_scope(&mut self) -> Scope {
         let loader = self.build_loader();
 
-        let mut names = NameStore::new();
+        let mut names = NameStore::default();
         let name = names.add(self.name.unwrap_or("main"));
 
         let names = Rc::new(RefCell::new(names));
-        let codemap = Rc::new(RefCell::new(CodeMap::new()));
+        let codemap = Rc::new(RefCell::new(CodeMap::default()));
         let modules = Rc::new(ModuleRegistry::new(loader));
         let io = self.io.take().unwrap_or_else(|| Rc::new(GlobalIo::default()));
         let defs = self.struct_defs.take().unwrap_or_else(
@@ -210,19 +212,21 @@ pub struct Interpreter {
     context: Context,
 }
 
-impl Interpreter {
+impl Default for Interpreter {
     /// Creates a new `Interpreter`.
-    pub fn new() -> Interpreter {
+    fn default() -> Interpreter {
         Interpreter::with_loader(Box::new(BuiltinModuleLoader))
     }
+}
 
+impl Interpreter {
     /// Creates a new `Interpreter` using the given `ModuleLoader` instance.
     pub fn with_loader(loader: Box<ModuleLoader>) -> Interpreter {
-        let mut names = NameStore::new();
+        let mut names = NameStore::default();
         let name = names.add("main");
 
         let names = Rc::new(RefCell::new(names));
-        let codemap = Rc::new(RefCell::new(CodeMap::new()));
+        let codemap = Rc::new(RefCell::new(CodeMap::default()));
         let modules = Rc::new(ModuleRegistry::new(loader));
         let io = Rc::new(GlobalIo::default());
         let defs = Rc::new(RefCell::new(StructDefMap::new()));

--- a/src/ketos/io.rs
+++ b/src/ketos/io.rs
@@ -48,9 +48,9 @@ impl IoError {
     /// Creates a new `IoError`.
     pub fn new(mode: IoMode, path: &Path, err: io::Error) -> IoError {
         IoError{
-            mode: mode,
+            mode,
             path: path.to_owned(),
-            err: err,
+            err,
         }
     }
 }

--- a/src/ketos/lexer.rs
+++ b/src/ketos/lexer.rs
@@ -145,15 +145,17 @@ struct File {
     begin: BytePos,
 }
 
-impl CodeMap {
+impl Default for CodeMap {
     /// Creates a new `CodeMap`.
-    pub fn new() -> CodeMap {
+    fn default() -> CodeMap {
         CodeMap{
             text: String::new(),
             files: Vec::new(),
         }
     }
+}
 
+impl CodeMap {
     /// Adds a source to the codemap, returning its offset in the internal buffer.
     pub fn add_source(&mut self, text: &str, path: Option<String>) -> BytePos {
         let begin = self.text.len() as BytePos;
@@ -239,7 +241,7 @@ impl<'lex> Lexer<'lex> {
     /// Creates a new `Lexer` to read tokens from the input string.
     pub fn new(input: &str, offset: BytePos) -> Lexer {
         Lexer{
-            input: input,
+            input,
             cur_pos: 0,
             code_offset: offset,
         }
@@ -337,7 +339,7 @@ impl<'lex> Lexer<'lex> {
             self.cur_pos += size as BytePos;
             self.input = &self.input[ind + size..];
 
-            let sp = Span{lo: lo, hi: lo + size as BytePos};
+            let sp = Span{lo, hi: lo + size as BytePos};
 
             return Ok((self.span(sp), tok));
         }
@@ -634,7 +636,7 @@ mod test {
     use parser::ParseErrorKind;
 
     fn sp(lo: BytePos, hi: BytePos) -> Span {
-        Span{lo: lo, hi: hi}
+        Span{lo, hi}
     }
 
     fn tokens(s: &str) -> Vec<(Span, Token)> {

--- a/src/ketos/lib.rs
+++ b/src/ketos/lib.rs
@@ -5,7 +5,7 @@
 //! use ketos::{Interpreter, FromValueRef};
 //!
 //! // Create an interpreter.
-//! let interp = Interpreter::new();
+//! let interp = Interpreter::default();
 //!
 //! // Define a function.
 //! interp.run_code(r#"

--- a/src/ketos/name.rs
+++ b/src/ketos/name.rs
@@ -23,7 +23,7 @@ impl Name {
     }
 
     /// Returns the integer key referring to this name.
-    pub fn get(&self) -> u32 {
+    pub fn get(self) -> u32 {
         self.0
     }
 }
@@ -320,15 +320,17 @@ pub struct NameInputConversion {
     next_value: u32,
 }
 
-impl NameInputConversion {
+impl Default for NameInputConversion {
     /// Creates a new `NameInputConversion` from a local-to-global mapping.
-    pub fn new() -> NameInputConversion {
+    fn default() -> NameInputConversion {
         NameInputConversion{
             map: HashMap::new(),
             next_value: NUM_STANDARD_NAMES,
         }
     }
+}
 
+impl NameInputConversion {
     /// Returns the global name value for the given module-local value.
     pub fn get(&self, name: u32) -> Option<Name> {
         get_standard_name(name).or_else(|| self.map.get(&name).cloned())
@@ -358,7 +360,7 @@ impl<'a> NameOutputConversion<'a> {
         NameOutputConversion{
             names: Vec::new(),
             map: HashMap::new(),
-            store: store,
+            store,
         }
     }
 
@@ -401,14 +403,16 @@ pub struct NameStore {
     names: Vec<Box<str>>,
 }
 
-impl NameStore {
+impl Default for NameStore {
     /// Constructs an empty `NameStore`.
-    pub fn new() -> NameStore {
+    fn default() -> NameStore {
         NameStore{
             names: Vec::new(),
         }
     }
+}
 
+impl NameStore {
     /// Adds a name to the `NameStore` if it is not present.
     /// Returns a `Name` value to refer to the new or existing name.
     pub fn add(&mut self, name: &str) -> Name {

--- a/src/ketos/parser.rs
+++ b/src/ketos/parser.rs
@@ -148,8 +148,8 @@ impl<'a, 'lex> Parser<'a, 'lex> {
     /// Identifiers received from the lexer will be inserted into the given context.
     pub fn new(ctx: &'a Context, lexer: Lexer<'lex>) -> Parser<'a, 'lex> {
         Parser{
-            lexer: lexer,
-            ctx: ctx,
+            lexer,
+            ctx,
             name_cache: HashMap::new(),
             cur_token: None,
         }
@@ -575,7 +575,7 @@ mod test {
     use value::Value;
 
     fn parse(s: &str) -> Result<Value, ParseError> {
-        let interp = Interpreter::new();
+        let interp = Interpreter::default();
 
         let mut p = Parser::new(interp.context(), Lexer::new(s, 0));
         p.parse_single_expr().map_err(|e| {
@@ -608,7 +608,7 @@ mod test {
 
     #[test]
     fn test_lexer_position() {
-        let interp = Interpreter::new();
+        let interp = Interpreter::default();
 
         let mut p = Parser::new(interp.context(),
             Lexer::new("(foo 1 2 3) bar", 0));

--- a/src/ketos/restrict.rs
+++ b/src/ketos/restrict.rs
@@ -19,7 +19,7 @@
 //! use std::rc::Rc;
 //! use ketos::{Builder, GlobalIo, BuiltinModuleLoader, RestrictConfig};
 //!
-//! let interp = Builder::new()
+//! let interp = Builder::default()
 //!     .restrict(RestrictConfig::strict())
 //!     .io(Rc::new(GlobalIo::null()))
 //!     .module_loader(Box::new(BuiltinModuleLoader))
@@ -85,10 +85,10 @@ pub enum RestrictError {
 
 impl RestrictError {
     /// Returns a string describing the error that occurred.
-    pub fn description(&self) -> &'static str {
+    pub fn description(self) -> &'static str {
         use self::RestrictError::*;
 
-        match *self {
+        match self {
             ExecutionTimeExceeded => "execution time exceeded",
             CallStackExceeded => "max call stack exceeded",
             ValueStackExceeded => "max value stack exceeded",

--- a/src/ketos/run.rs
+++ b/src/ketos/run.rs
@@ -41,7 +41,7 @@ mod test {
 
     #[test]
     fn test_run() {
-        let interp = Interpreter::new();
+        let interp = Interpreter::default();
 
         run_code(interp.context(), "(define foo ())").unwrap();
 

--- a/src/ketos/scope.rs
+++ b/src/ketos/scope.rs
@@ -57,7 +57,7 @@ impl ImportSet {
     /// Convenience method to create an empty `ImportSet` for the named module.
     pub fn new(module_name: Name) -> ImportSet {
         ImportSet{
-            module_name: module_name,
+            module_name,
             names: Vec::new(),
         }
     }
@@ -78,23 +78,23 @@ impl GlobalScope {
             io: Rc<GlobalIo>,
             struct_defs: Rc<RefCell<StructDefMap>>) -> GlobalScope {
         GlobalScope{
-            name: name,
+            name,
             namespace: RefCell::new(Namespace::new()),
             name_store: names,
-            codemap: codemap,
+            codemap,
             modules: registry,
-            io: io,
-            struct_defs: struct_defs,
+            io,
+            struct_defs,
         }
     }
 
     /// Creates a new global scope with the given name and default environment.
     pub fn default(name: &str) -> GlobalScope {
-        let mut names = NameStore::new();
+        let mut names = NameStore::default();
         let name = names.add(name);
 
         let names = Rc::new(RefCell::new(names));
-        let codemap = Rc::new(RefCell::new(CodeMap::new()));
+        let codemap = Rc::new(RefCell::new(CodeMap::default()));
         let modules = Rc::new(ModuleRegistry::new(Box::new(BuiltinModuleLoader)));
         let io = Rc::new(GlobalIo::default());
         let struct_defs = Rc::new(RefCell::new(StructDefMap::new()));
@@ -517,8 +517,8 @@ impl MasterScope {
 
     fn get_function(name: Name) -> Option<Value> {
         get_system_fn(name).map(|f| Value::Function(Function{
-            name: name,
-            sys_fn: f.clone(),
+            name,
+            sys_fn: *f,
         }))
     }
 }

--- a/src/ketos/string.rs
+++ b/src/ketos/string.rs
@@ -63,7 +63,7 @@ impl<'a> StringReader<'a> {
             start: pos,
             last_index: 0,
             end_index: 0,
-            ty: ty,
+            ty,
         }
     }
 

--- a/src/ketos/string_fmt.rs
+++ b/src/ketos/string_fmt.rs
@@ -161,8 +161,8 @@ impl Group {
         }
     }
 
-    fn close_delim(&self) -> char {
-        match *self {
+    fn close_delim(self) -> char {
+        match self {
             Group::CaseConversion => ')',
             Group::Conditional => ']',
             Group::Iteration => '}',
@@ -198,7 +198,7 @@ struct FieldParser<'a> {
 
 impl<'a> FieldParser<'a> {
     fn new(s: &str) -> FieldParser {
-        FieldParser{s: s, chars: s.char_indices()}
+        FieldParser{s, chars: s.char_indices()}
     }
 
     fn rest(mut self) -> &'a str {
@@ -252,8 +252,8 @@ impl<'fmt, 'names, 'value> StringFormatter<'fmt, 'names, 'value> {
             fmt: s,
             full_fmt: s,
             chars: s.char_indices(),
-            values: values,
-            names: names,
+            values,
+            names,
             groups: Vec::new(),
             close_dir: None,
             terminate: false,
@@ -461,10 +461,10 @@ impl<'fmt, 'names, 'value> StringFormatter<'fmt, 'names, 'value> {
                 }
                 Some(ch) => {
                     return Ok(Directive{
-                        at: at,
-                        colon: colon,
+                        at,
+                        colon,
                         command: ch.to_ascii_lowercase(),
-                        fields: fields,
+                        fields,
                         span: self.span_start(start),
                     })
                 }
@@ -1456,7 +1456,7 @@ impl<'fmt, 'names, 'value> StringFormatter<'fmt, 'names, 'value> {
         ExecError::FormatError{
             fmt: self.full_fmt.to_owned().into_boxed_str(),
             span: Span{lo: span.lo + off, hi: span.hi + off},
-            err: err,
+            err,
         }
     }
 
@@ -1654,7 +1654,7 @@ fn make_first_uppercase(s: &mut String, start: usize) {
     };
 
     if ch.is_ascii() {
-        s[ind..ind + 1].make_ascii_uppercase();
+        s[ind..=ind].make_ascii_uppercase();
     } else {
         // Removing and inserting is slow, but what alternative do we have?
         let ch = s.remove(ind);

--- a/src/ketos/string_fmt.rs
+++ b/src/ketos/string_fmt.rs
@@ -6,6 +6,7 @@ use std::f64;
 use std::fmt;
 use std::iter::repeat;
 use std::str::CharIndices;
+use std::f64::EPSILON;
 
 use num::ToPrimitive;
 
@@ -575,7 +576,7 @@ impl<'fmt, 'names, 'value> StringFormatter<'fmt, 'names, 'value> {
 
         let arg = self.consume_arg(dir.span)?;
         let is_one = match *arg {
-            Value::Float(f) => f == 1.0,
+            Value::Float(f) => (f - 1.0).abs() < EPSILON,
             Value::Integer(ref i) => i == &Integer::one(),
             Value::Ratio(ref r) => r.numer() == r.denom(),
             ref v => return Err(self.error(dir.span,

--- a/src/ketos/value.rs
+++ b/src/ketos/value.rs
@@ -1,7 +1,7 @@
 //! Represents any possible value type.
 
 use std::cmp::Ordering;
-use std::f64::{INFINITY, NEG_INFINITY};
+use std::f64::{INFINITY, NEG_INFINITY, EPSILON};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::mem::replace;
@@ -173,7 +173,7 @@ impl Value {
         let eq = match (self, rhs) {
             (&Value::Unit, &Value::Unit) => true,
             (&Value::Bool(a), &Value::Bool(b)) => a == b,
-            (&Value::Float(a), &Value::Float(b)) => a == b,
+            (&Value::Float(a), &Value::Float(b)) => (a - b).abs() < EPSILON,
             (&Value::Integer(ref a), &Value::Integer(ref b)) => a == b,
             (&Value::Ratio(ref a), &Value::Ratio(ref b)) => a == b,
 
@@ -720,7 +720,7 @@ fn coerce_equal_float(f: f64, other: Option<f64>) -> bool {
     if f.is_infinite() || f.is_nan() {
         false
     } else {
-        other.map_or(false, |other| f == other)
+        other.map_or(false, |other| (f - other).abs() < EPSILON)
     }
 }
 

--- a/src/ketos/value.rs
+++ b/src/ketos/value.rs
@@ -1054,7 +1054,7 @@ value_from!{ String; s => Value::String(RcString::new(s)) }
 value_from!{ Bytes; s => Value::Bytes(s) }
 value_from!{ PathBuf; p => Value::Path(p) }
 value_from!{ OsString; s => Value::Path(PathBuf::from(s)) }
-value_from!{ f32; f => Value::Float(f as f64) }
+value_from!{ f32; f => Value::Float(f64::from(f)) }
 value_from!{ f64; f => Value::Float(f) }
 
 impl<'a> From<&'a str> for Value {

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -5,7 +5,7 @@ use ketos::bytecode::opcodes::*;
 use ketos::name::standard_names;
 
 fn lambda(s: &str) -> Result<Vec<u8>, Error> {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
     let _exprs = interp.compile_exprs(s)?;
 
     match interp.scope().get_named_value("test") {

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -5,14 +5,14 @@ extern crate ketos;
 use ketos::{CompileError, Error, ExecError, Interpreter, FromValue, Value};
 
 fn eval(s: &str) -> Result<String, Error> {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     let v = interp.run_single_expr(s, None)?;
     Ok(interp.format_value(&v))
 }
 
 fn eval_str(s: &str) -> Result<String, Error> {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     let v = interp.run_single_expr(s, None)?;
 
@@ -21,7 +21,7 @@ fn eval_str(s: &str) -> Result<String, Error> {
 }
 
 fn run(s: &str) -> Result<Vec<String>, Error> {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     let c = interp.compile_exprs(s)?;
     c.into_iter().map(|c| interp.execute(c)

--- a/tests/foreign.rs
+++ b/tests/foreign.rs
@@ -43,7 +43,7 @@ fn eval(interp: &Interpreter, input: &str) -> Result<String, Error> {
 
 #[test]
 fn test_foreign_value() {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     interp.scope().add_named_value("my-value", MyType{a: 123}.into());
 
@@ -58,7 +58,7 @@ fn reflect_args(_ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 
 #[test]
 fn test_raw_foreign_fn() {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     interp.scope().add_value_with_name("reflect-args",
         |name| Value::new_foreign_fn(name, reflect_args));
@@ -89,7 +89,7 @@ fn hello(s: &str) -> Result<String, Error> {
 
 #[test]
 fn test_foreign_fn() {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
     let scope = interp.scope();
 
     ketos_fn!{ scope => "new-my-type" => fn new_my_type(a: i32) -> MyType }
@@ -108,7 +108,7 @@ fn test_foreign_fn() {
 
 #[test]
 fn test_compare_foreign_value() {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
     let scope = interp.scope();
 
     ketos_fn!{ scope => "new-my-type" => fn new_my_type(a: i32) -> MyType }

--- a/tests/restrict.rs
+++ b/tests/restrict.rs
@@ -11,7 +11,7 @@ use ketos::{
 };
 
 fn run(restrict: RestrictConfig, code: &str) -> Result<(), Error> {
-    let interp = Builder::new()
+    let interp = Builder::default()
         .restrict(restrict)
         .finish();
 

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -18,7 +18,7 @@ struct Bar {
 }
 
 fn interp() -> Interpreter {
-    let interp = Interpreter::new();
+    let interp = Interpreter::default();
 
     interp.scope().register_struct_value::<Foo>();
     interp.scope().register_struct_value::<Bar>();


### PR DESCRIPTION
This addresses all clippy warnings except for one, which might not be fixable due to conflicts with the borrow checker.

Note that this includes some API changes: any `new` methods that did not take parameters was changed to `impl Default`.