### PR TITLE
Added built-in functions for printing to stderr

### DIFF
--- a/src/ketos/function.rs
+++ b/src/ketos/function.rs
@@ -251,6 +251,10 @@ Creates a struct value."),
 "Prints a formatted string to `stdout`."),
     sys_fn!(fn_println,     Min(1),
 "Prints a formatted string to `stdout`, followed by a newline."),
+    sys_fn!(fn_eprint,       Min(1),
+"Prints a formatted string to `stderr`."),
+    sys_fn!(fn_eprintln,     Min(1),
+"Prints a formatted string to `stderr`, followed by a newline."),
     sys_fn!(fn_panic,       Range(0, 1),
 "Immediately interrupts execution upon evaluation.
 
@@ -1387,6 +1391,35 @@ fn fn_println(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
 
     scope.io().stdout.write_all(s.as_bytes())?;
     scope.io().stdout.flush()?;
+
+    Ok(Value::Unit)
+}
+
+/// `eprint` prints a formatted string to `stderr`.
+fn fn_eprint(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
+    let fmt = get_string(&args[0])?;
+    let scope = ctx.scope();
+
+    let s = format_string(&scope.borrow_names(), fmt, &args[1..])?;
+
+    scope.io().stderr.write_all(s.as_bytes())?;
+    scope.io().stderr.flush()?;
+
+    Ok(Value::Unit)
+}
+
+/// `println` prints a formatted string to `stdout`, followed by a newline.
+fn fn_eprintln(ctx: &Context, args: &mut [Value]) -> Result<Value, Error> {
+    let fmt = get_string(&args[0])?;
+    let scope = ctx.scope();
+
+    let mut s = format_string(&scope.borrow_names(), fmt, &args[1..])?;
+    if !s.ends_with('\n') {
+        s.push('\n');
+    }
+
+    scope.io().stderr.write_all(s.as_bytes())?;
+    scope.io().stderr.flush()?;
 
     Ok(Value::Unit)
 }

--- a/src/ketos/io.rs
+++ b/src/ketos/io.rs
@@ -12,24 +12,28 @@ use name::{NameDisplay, NameStore};
 pub struct GlobalIo {
     /// Shared standard output writer
     pub stdout: Rc<SharedWrite>,
+
+    /// Shared standard error writer
+    pub stderr: Rc<SharedWrite>,
 }
 
 impl GlobalIo {
-    /// Creates a `GlobalIo` instance using the given `stdout` writer.
-    pub fn new(stdout: Rc<SharedWrite>) -> GlobalIo {
-        GlobalIo{ stdout }
+    /// Creates a `GlobalIo` instance using the given `stdout` and `stderr`
+    /// writers.
+    pub fn new(stdout: Rc<SharedWrite>, stderr: Rc<SharedWrite>) -> GlobalIo {
+        GlobalIo{ stdout, stderr }
     }
 
-    /// Creates a `GlobalIo` instance whose `stdout` ignores all output.
+    /// Creates a `GlobalIo` instance that ignores all output.
     pub fn null() -> GlobalIo {
-        GlobalIo::new(Rc::new(Sink))
+        GlobalIo::new(Rc::new(Sink), Rc::new(Sink))
     }
 }
 
 impl Default for GlobalIo {
-    /// Creates a `GlobalIo` instance using standard output writer.
+    /// Creates a `GlobalIo` instance using `stdout`/`stderr` writers.
     fn default() -> GlobalIo {
-        GlobalIo::new(Rc::new(io::stdout()))
+        GlobalIo::new(Rc::new(io::stdout()), Rc::new(io::stderr()))
     }
 }
 

--- a/src/ketos/name.rs
+++ b/src/ketos/name.rs
@@ -169,74 +169,76 @@ standard_names!{
     "format" => FORMAT = 63,
     "print" => PRINT = 64,
     "println" => PRINTLN = 65,
-    "panic" => PANIC = 66,
-    "xor" => XOR = 67,
-    "not" => NOT = 68,
+    "eprint" => EPRINT = 66,
+    "eprintln" => EPRINTLN = 67,
+    "panic" => PANIC = 68,
+    "xor" => XOR = 69,
+    "not" => NOT = 70,
     // End of names referring to system functions.
     // The constant `NUM_SYSTEM_FNS` below should be one greater than
     // the value immediately above this comment.
 
     // Boolean names; the parser will replace these with boolean values.
     // These names must follow immediately after system function names.
-    "false" => FALSE = 69,
-    "true" => TRUE = 70,
+    "false" => FALSE = 71,
+    "true" => TRUE = 72,
     // End of names referring to standard values.
     // The constant `NUM_STANDARD_VALUES` below should be one greater than
     // the value immediately above this comment.
 
     // Special operators follow; these are not represented as values in global
     // scope. They are only handled by the compiler.
-    "apply" => APPLY = 71,
-    "do" => DO = 72,
-    "let" => LET = 73,
-    "define" => DEFINE = 74,
-    "macro" => MACRO = 75,
-    "struct" => STRUCT = 76,
-    "if" => IF = 77,
-    "and" => AND = 78,
-    "or" => OR = 79,
-    "case" => CASE = 80,
-    "cond" => COND = 81,
-    "lambda" => LAMBDA = 82,
-    "export" => EXPORT = 83,
-    "use" => USE = 84,
-    "const" => CONST = 85,
-    "set-module-doc" => SET_MODULE_DOC = 86,
+    "apply" => APPLY = 73,
+    "do" => DO = 74,
+    "let" => LET = 75,
+    "define" => DEFINE = 76,
+    "macro" => MACRO = 77,
+    "struct" => STRUCT = 78,
+    "if" => IF = 79,
+    "and" => AND = 80,
+    "or" => OR = 81,
+    "case" => CASE = 82,
+    "cond" => COND = 83,
+    "lambda" => LAMBDA = 84,
+    "export" => EXPORT = 85,
+    "use" => USE = 86,
+    "const" => CONST = 87,
+    "set-module-doc" => SET_MODULE_DOC = 88,
 
     // Just plain names follow; these are used by system functions or operators
     // to delineate syntactical constructs or just as name values.
-    "all" => ALL = 87,
-    "else" => ELSE = 88,
-    "optional" => OPTIONAL = 89,
-    "key" => KEY = 90,
-    "rest" => REST = 91,
-    "unbound" => UNBOUND = 92,
-    "unit" => UNIT = 93,
-    "bool" => BOOL = 94,
-    "char" => CHAR = 95,
-    "integer" => INTEGER = 96,
-    "ratio" => RATIO = 97,
-    "struct-def" => STRUCT_DEF = 98,
-    "keyword" => KEYWORD = 99,
-    "object" => OBJECT = 100,
-    "name" => NAME = 101,
-    "number" => NUMBER = 102,
-    "function" => FUNCTION = 103,
+    "all" => ALL = 89,
+    "else" => ELSE = 90,
+    "optional" => OPTIONAL = 91,
+    "key" => KEY = 92,
+    "rest" => REST = 93,
+    "unbound" => UNBOUND = 94,
+    "unit" => UNIT = 95,
+    "bool" => BOOL = 96,
+    "char" => CHAR = 97,
+    "integer" => INTEGER = 98,
+    "ratio" => RATIO = 99,
+    "struct-def" => STRUCT_DEF = 100,
+    "keyword" => KEYWORD = 101,
+    "object" => OBJECT = 102,
+    "name" => NAME = 103,
+    "number" => NUMBER = 104,
+    "function" => FUNCTION = 105,
 }
 
 /// Number of standard names
-pub const NUM_STANDARD_NAMES: u32 = 104;
+pub const NUM_STANDARD_NAMES: u32 = 106;
 
 /// Number of names, starting at `0`, which refer to system functions.
-pub const NUM_SYSTEM_FNS: usize = 69;
+pub const NUM_SYSTEM_FNS: usize = 71;
 
 /// Number of names, starting at `0`, which refer to standard values.
-pub const NUM_STANDARD_VALUES: u32 = 71;
+pub const NUM_STANDARD_VALUES: u32 = 73;
 
 /// First standard name which refers to a system operator.
 pub const SYSTEM_OPERATORS_BEGIN: u32 = NUM_STANDARD_VALUES;
 /// One-past-the-end of standard names which refer to system operators.
-pub const SYSTEM_OPERATORS_END: u32 = 87;
+pub const SYSTEM_OPERATORS_END: u32 = 89;
 
 /// Number of system operators, beginning at `SYSTEM_OPERATORS_BEGIN`.
 pub const NUM_SYSTEM_OPERATORS: usize =


### PR DESCRIPTION
This adds `eprint`/`eprintln`, which prints to stderr. This would break bytecode compatibility.