### PR TITLE
Add basic time module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand = "0.5"
 serde = { version = "1.0", optional = true }
 # Used only in `tests/value_derive.rs`
 serde_derive = { version = "1.0", optional = true }
+chrono = "0.4"
 
 [dev-dependencies]
 assert_matches = "1.0"

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -38,3 +38,10 @@ The `random` module provides access to random number generation functions.
 
 * `random` returns a random float value in the range `[0.0, 1.0)`.
 * `shuffle` returns a given list in random order.
+
+## `time`
+
+The `time` module provides access to the current time.
+
+* `utc-timestamp` returns the number of non-leap seconds observed in the UTC timezone since January 1st 1970.
+* `local-timestamp` returns the number of non-leap seconds observed in the local timezone since January 1st 1970.

--- a/src/ketos/lib.rs
+++ b/src/ketos/lib.rs
@@ -93,3 +93,4 @@ pub mod value;
 mod mod_code;
 mod mod_math;
 mod mod_random;
+mod mod_time;

--- a/src/ketos/mod_time.rs
+++ b/src/ketos/mod_time.rs
@@ -1,0 +1,32 @@
+//! Implements builtin `random` module.
+
+use chrono::offset::{Utc, Local};
+
+use crate::error::Error;
+use crate::exec::Context;
+use crate::function::Arity::Exact;
+use crate::module::{Module, ModuleBuilder};
+use crate::scope::Scope;
+use crate::value::Value;
+
+/// Loads the `random` module into the given scope.
+pub fn load(scope: Scope) -> Module {
+    ModuleBuilder::new("time", scope)
+        .add_function("utc-timestamp",  fn_utc_timestamp,  Exact(0),
+            Some("Returns the number of non-leap seconds observed in the UTC timezone since January 1st 1970."))
+        .add_function("local-timestamp",  fn_local_timestamp,  Exact(0),
+            Some("Returns the number of non-leap seconds observed in the local timezone since January 1st 1970."))
+        .finish()
+}
+
+/// `utc-timestamp` the number of non-leap seconds observed in the UTC timezone since January 1st 1970.
+fn fn_utc_timestamp(_ctx: &Context, _args: &mut [Value]) -> Result<Value, Error> {
+    let time = Utc::now().timestamp();
+    Ok(time.into())
+}
+
+/// `utc-timestamp` the number of non-leap seconds observed in the local timezone since January 1st 1970.
+fn fn_local_timestamp(_ctx: &Context, _args: &mut [Value]) -> Result<Value, Error> {
+    let time = Local::now().timestamp();
+    Ok(time.into())
+}

--- a/src/ketos/module.rs
+++ b/src/ketos/module.rs
@@ -22,6 +22,7 @@ use crate::value::Value;
 use crate::mod_code;
 use crate::mod_math;
 use crate::mod_random;
+use crate::mod_time;
 
 /// Contains the values in a loaded module's namespace.
 #[derive(Clone)]
@@ -327,6 +328,7 @@ fn get_loader(name: &str) -> Option<fn(Scope) -> Module> {
         "code" => Some(mod_code::load),
         "math" => Some(mod_math::load),
         "random" => Some(mod_random::load),
+        "time" => Some(mod_time::load),
         _ => None
     }
 }


### PR DESCRIPTION
This pull request would add a basic time module.  The module provides two functions (`utc-timestamp` and `local-timestamp`) that return the current time in UTC or your local timezone as the number of seconds since January 1st 1970.  The module uses chrono::offset to get the time in UTC and your local timezone and will add a dependency on chrono version 0.4.

If anyone would like to write a more complete time library I can help.  This module is currently an minimal implementation containing only what I need.