### PR TITLE
WebAssembly support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 name = "ketos"
 path = "src/bin/repl.rs"
 doc = false
+required-features = ["repl"]
 
 [lib]
 name = "ketos"
@@ -25,22 +26,25 @@ path = "src/ketos/lib.rs"
 
 [dependencies]
 byteorder = "1.3"
-dirs = "2.0"
-gumdrop = "0.7"
 ketos_derive = { version = "0.12", path = "ketos_derive", optional = true }
-linefeed = "0.6"
 num = "0.2"
 rand = "0.7"
 serde = { version = "1.0", optional = true }
 # Used only in `tests/value_derive.rs`
 serde_derive = { version = "1.0", optional = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dirs = { version = "2.0", optional = true }
+gumdrop = "0.7"
+linefeed = { version = "0.6", optional = true }
+
 [dev-dependencies]
 assert_matches = "1.0"
 ketos_derive = { version = "0.12", path = "ketos_derive" }
 
 [features]
-default = []
+default = ["repl"]
 derive = ["ketos_derive"]
+repl = ["dirs", "linefeed"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Build optimized executable:
 `ketos` can be run as an interpreter to execute Ketos code files (`.ket`)
 or run as an interactive read-eval-print loop.
 
+## WebAssembly
+
+This library supports compiling to WebAssembly, but some internal APIs are only
+available on the nightly compiler. Include `ketos` in your `Cargo.toml` like so:
+
+```toml
+[dependencies]
+ketos = { version = "x.y.z", default-features = false }
+```
+
 ## License
 
 Ketos is distributed under the terms of both the MIT license and the

--- a/src/ketos/compile.rs
+++ b/src/ketos/compile.rs
@@ -330,7 +330,8 @@ impl<'a> Compiler<'a> {
             }
         }
 
-        replace(&mut self.blocks, new_blocks);
+        // drop the old value
+        let _ = replace(&mut self.blocks, new_blocks);
 
         for block in &mut self.blocks {
             if let Some((_, dest)) = block.jump {

--- a/src/ketos/lib.rs
+++ b/src/ketos/lib.rs
@@ -47,7 +47,9 @@ pub use crate::function::Arity;
 pub use crate::interpreter::{Builder, Interpreter};
 pub use crate::integer::{Integer, Ratio};
 pub use crate::io::{File, GlobalIo, IoError, SharedWrite};
-pub use crate::module::{BuiltinModuleLoader, FileModuleLoader, Module, ModuleBuilder, ModuleLoader};
+pub use crate::module::{BuiltinModuleLoader, Module, ModuleBuilder, ModuleLoader};
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::module::{FileModuleLoader};
 pub use crate::name::{Name, NameStore};
 pub use crate::parser::{ParseError, ParseErrorKind};
 pub use crate::restrict::{RestrictConfig, RestrictError};

--- a/src/ketos/module.rs
+++ b/src/ketos/module.rs
@@ -1,20 +1,29 @@
 //! Implements loading named values from code modules.
 
 use std::cell::RefCell;
+#[cfg(not(target_arch = "wasm32"))]
 use std::fs::{File, Metadata};
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::{stderr, Read, Write};
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use crate::bytecode::Code;
-use crate::compile::{compile, CompileError};
+use crate::compile::CompileError;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::compile::compile;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::encode::{DecodeError, read_bytecode_file, write_bytecode_file};
 use crate::error::Error;
 use crate::exec::{Context, execute};
 use crate::function::{Arity, Function, FunctionImpl, Lambda, SystemFn};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::io::{IoError, IoMode};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::lexer::Lexer;
 use crate::name::{Name, NameMap, NameSetSlice};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::parser::Parser;
 use crate::scope::{GlobalScope, ImportSet, Scope};
 use crate::value::Value;
@@ -341,6 +350,7 @@ fn load_builtin_module(name: Name, scope: &Scope) -> Result<Module, Error> {
 }
 
 /// Loads modules from source files and compiled bytecode files.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct FileModuleLoader {
     /// Tracks import chains to prevent infinite recursion
     chain: RefCell<Vec<PathBuf>>,
@@ -358,6 +368,7 @@ pub const FILE_EXTENSION: &str = "ket";
 /// File extension for `ketos` compiled bytecode files.
 pub const COMPILED_FILE_EXTENSION: &str = "ketc";
 
+#[cfg(not(target_arch = "wasm32"))]
 impl FileModuleLoader {
     /// Creates a new `FileModuleLoader` that will search the current
     /// directory for modules.
@@ -407,6 +418,7 @@ impl FileModuleLoader {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ModuleLoader for FileModuleLoader {
     fn load_module(&self, name: Name, ctx: Context) -> Result<Module, Error> {
         let (src_fname, code_fname) = ctx.scope().with_name(name, |name_str| {
@@ -474,12 +486,14 @@ impl ModuleLoader for FileModuleLoader {
 }
 
 #[derive(Copy, Clone)]
+#[cfg(not(target_arch = "wasm32"))]
 enum ModuleFileResult {
     NotFound,
     UseCode,
     UseSource,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn find_module_file(src_path: &Path, code_path: &Path) -> Result<ModuleFileResult, Error> {
     match (code_path.exists(), src_path.exists()) {
         (true, true) if is_younger(code_path, src_path)? =>
@@ -490,6 +504,7 @@ fn find_module_file(src_path: &Path, code_path: &Path) -> Result<ModuleFileResul
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn find_source_file(src_path: &Path) -> ModuleFileResult {
     if src_path.exists() {
         ModuleFileResult::UseSource
@@ -498,6 +513,7 @@ fn find_source_file(src_path: &Path) -> ModuleFileResult {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn is_younger(a: &Path, b: &Path) -> Result<bool, Error> {
     let ma = a.metadata()
         .map_err(|e| IoError::new(IoMode::Stat, a, e))?;
@@ -519,6 +535,7 @@ fn is_younger_impl(ma: &Metadata, mb: &Metadata) -> bool {
     ma.last_write_time() > mb.last_write_time()
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn load_module_from_file(ctx: Context, name: Name,
         src_path: &Path, code_path: Option<&Path>) -> Result<Module, Error> {
     let mut file = File::open(src_path)
@@ -611,6 +628,7 @@ fn process_imports(ctx: &Context, imports: &[ImportSet]) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn check_exports(scope: &Scope, mod_name: Name) -> Result<(), CompileError> {
     scope.with_exports(|exports| {
         for name in exports {

--- a/src/ketos/structs.rs
+++ b/src/ketos/structs.rs
@@ -113,7 +113,7 @@ impl<T: StructValue> ForeignStructDef<T> {
     fn get_rc(&self, value: Value) -> Rc<T> {
         match value {
             Value::Foreign(fv) => {
-                ForeignValue::downcast_rc::<T>(fv)
+                <dyn ForeignValue>::downcast_rc::<T>(fv)
                     .expect("invalid foreign value for ForeignStructDef")
             }
             _ => panic!("invalid value for ForeignStructDef")

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 #[macro_use] extern crate assert_matches;
 extern crate ketos;
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 extern crate ketos;
 
 use ketos::{

--- a/tests/value_encode.rs
+++ b/tests/value_encode.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "serde", feature = "serde_derive"))]
+#![cfg(all(feature = "serde", feature = "serde_derive", not(target_arch = "wasm32")))]
 
 extern crate ketos;
 extern crate serde;


### PR DESCRIPTION
Adds conditional compilation for the `wasm32` target to enable wasm support. Tested with a small program on Firefox 88.0.1 and it works well enough. It requires a nightly compiler to access `std::time::Instant` in a way that doesn't panic. Possibly as a result of using the nightly compiler, it errors on test execution with the following:

```
$ cargo test --target wasm32-unknown-unknown --no-default-features
...
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests (target/wasm32-unknown-unknown/debug/deps/ketos-951c6b0f1e1fa322.wasm)
/home/user/code/misc/ketos/target/wasm32-unknown-unknown/debug/deps/ketos-951c6b0f1e1fa322.wasm: 1: /home/user/code/misc/ketos/target/wasm32-unknown-unknown/debug/deps/ketos-951c6b0f1e1fa322.wasm: Syntax error: end of file unexpected
```