### PR TITLE
make serde_derive a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,11 @@ linefeed = "0.6"
 num = "0.2"
 rand = "0.7"
 serde = { version = "1.0", optional = true }
-# Used only in `tests/value_derive.rs`
-serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.0"
 ketos_derive = { version = "0.12", path = "ketos_derive" }
+serde_derive = "1.0"
 
 [features]
 default = []


### PR DESCRIPTION
Reduce download/compilation time. Passes `cargo check` and `cargo test`